### PR TITLE
Explicitly set Nexus Staging Profile ID

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,5 +53,6 @@ jobs:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository --info -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.http.connectionTimeout=180000
         env:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE  }}

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,10 @@ nexusPublishing {
 
       username = "$sonatypeUsername"
       password = System.getenv("SONATYPE_PASSWORD")
+
+      // Specifying the configuration property explicitly rather than relying on the API call
+      // is considered a performance optimization and can reduce execution time by several seconds
+      stagingProfileId = System.getenv("SONATYPE_STAGING_PROFILE_ID")
     }
   }
 }


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information
* nrich version: v1.1.0
  <!-- released version or snapshot version -->
* Module: project
  <!-- Please, include name(s) of relevant nrich's module(s). If not related to any specific module, specify "project" instead. -->

## Description
### Summary
As specified in the [Nexus Publish Plugin documentation](https://github.com/gradle-nexus/publish-plugin#behind-the-scenes) it's recommended to manually fetch the Nexus Staging Profile ID and explicitly configure it for the plugin, in order to enhance performance, and reduce execution time by several seconds, by avoiding 1 GET call to retrieve the ID.
<!--- Please, provide a short summary of your changes. -->

### Details
<!--- Please, describe your changes in detail. -->
- explicitly set fetched Staging Profile ID for plugin
- set GH secret and pass as env variable to relevant GH action

## Types of changes
<!--- What types of changes does your code introduce? Please, put an "x" in all the boxes that apply. -->
- Enhancement (non-breaking change which enhances existing functionality)

## Checklist
<!--- Please, go over all the following points, and put an "x" in all the boxes that apply. -->
- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] All new and existing tests pass.
