### PR TITLE
Add missing conditional on bean

### DIFF
--- a/nrich-form-configuration-spring-boot-starter/src/main/java/net/croz/nrich/formconfiguration/starter/configuration/NrichFormConfigurationAutoConfiguration.java
+++ b/nrich-form-configuration-spring-boot-starter/src/main/java/net/croz/nrich/formconfiguration/starter/configuration/NrichFormConfigurationAutoConfiguration.java
@@ -58,6 +58,7 @@ public class NrichFormConfigurationAutoConfiguration {
         return new DefaultFormConfigurationService(validator, formConfigurationMapping, constrainedPropertyValidatorConverterServiceList);
     }
 
+    @ConditionalOnMissingBean
     @Bean
     public FormConfigurationController formConfigurationController(FormConfigurationService formConfigurationService) {
         return new FormConfigurationController(formConfigurationService);

--- a/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfiguration.java
+++ b/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfiguration.java
@@ -157,7 +157,8 @@ public class NrichRegistryAutoConfiguration {
         return new DefaultRegistryConfigurationService(messageSource, readOnlyPropertyList, registryGroupDefinitionHolder, registryHistoryConfigurationHolder, registryOverrideConfigurationMap);
     }
 
-    @ConditionalOnWebApplication
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+    @ConditionalOnMissingBean
     @Bean
     public RegistryConfigurationController registryConfigurationController(RegistryConfigurationService registryConfigurationService) {
         return new RegistryConfigurationController(registryConfigurationService);
@@ -171,6 +172,7 @@ public class NrichRegistryAutoConfiguration {
         return new EntityManagerRegistryEntityFinderService(entityManager, registryBaseModelMapper, managedTypeWrapperMap);
     }
 
+    @ConditionalOnMissingBean
     @Bean
     public RegistryDataService registryDataService(ModelMapper registryDataModelMapper, StringToEntityPropertyMapConverter registryStringToEntityPropertyMapConverter,
                                                    RegistryConfigurationResolverService registryConfigurationResolverService,
@@ -192,13 +194,15 @@ public class NrichRegistryAutoConfiguration {
         return new DefaultRegistryDataRequestConversionService(objectMapper, registryDataConfigurationHolder);
     }
 
-    @ConditionalOnWebApplication
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+    @ConditionalOnMissingBean
     @Bean
     public RegistryDataController registryDataController(RegistryDataService registryDataService, RegistryDataRequestConversionService registryDataRequestConversionService, Validator validator) {
         return new RegistryDataController(registryDataService, registryDataRequestConversionService, validator);
     }
 
     @ConditionalOnClass(name = ENVERS_AUDIT_READER_FACTORY)
+    @ConditionalOnMissingBean
     @Bean
     public RegistryHistoryService registryHistoryService(RegistryConfigurationResolverService registryConfigurationResolverService, ModelMapper registryBaseModelMapper,
                                                          RegistryEntityFinderService registryEntityFinderService) {
@@ -209,13 +213,15 @@ public class NrichRegistryAutoConfiguration {
     }
 
     @ConditionalOnClass(name = ENVERS_AUDIT_READER_FACTORY)
-    @ConditionalOnWebApplication
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+    @ConditionalOnMissingBean
     @Bean
     public RegistryHistoryController registryHistoryController(RegistryHistoryService registryHistoryService) {
         return new RegistryHistoryController(registryHistoryService);
     }
 
     @ConditionalOnBean(name = FORM_CONFIGURATION_MAPPING_BEAN_NAME)
+    @ConditionalOnMissingBean
     @Bean
     public RegistryDataFormConfigurationResolverService registryFormConfigurationRegistrationService(RegistryConfigurationResolverService registryConfigurationResolverService,
                                                                                                      @Qualifier(FORM_CONFIGURATION_MAPPING_BEAN_NAME) Map<String, Class<?>> formConfigurationMapping) {

--- a/nrich-security-csrf-spring-boot-starter/src/main/java/net/croz/nrich/security/csrf/configuration/NrichCsrfAutoConfiguration.java
+++ b/nrich-security-csrf-spring-boot-starter/src/main/java/net/croz/nrich/security/csrf/configuration/NrichCsrfAutoConfiguration.java
@@ -35,6 +35,7 @@ public class NrichCsrfAutoConfiguration {
     }
 
     @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+    @ConditionalOnMissingBean
     @Bean
     public CsrfInterceptor csrfInterceptor(CsrfTokenManagerService csrfTokenManagerService, NrichCsrfProperties csrfProperties) {
         return new CsrfInterceptor(
@@ -43,6 +44,7 @@ public class NrichCsrfAutoConfiguration {
     }
 
     @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+    @ConditionalOnMissingBean
     @Bean
     public CsrfWebFilter webFilter(CsrfTokenManagerService csrfTokenManagerService, NrichCsrfProperties csrfProperties) {
         return new CsrfWebFilter(

--- a/nrich-webmvc-spring-boot-starter/src/main/java/net/croz/nrich/webmvc/starter/configuration/NrichWebMvcAutoConfiguration.java
+++ b/nrich-webmvc-spring-boot-starter/src/main/java/net/croz/nrich/webmvc/starter/configuration/NrichWebMvcAutoConfiguration.java
@@ -40,6 +40,7 @@ public class NrichWebMvcAutoConfiguration {
         return new DefaultExceptionAuxiliaryDataResolverService();
     }
 
+    @ConditionalOnMissingBean
     @Bean
     public ControllerEditorRegistrationAdvice controllerEditorRegistrationAdvice(NrichWebMvcProperties webMvcProperties, TransientPropertyResolverService transientPropertyResolverService) {
         return new ControllerEditorRegistrationAdvice(webMvcProperties.isConvertEmptyStringsToNull(), webMvcProperties.isIgnoreTransientFields(), transientPropertyResolverService);
@@ -54,9 +55,8 @@ public class NrichWebMvcAutoConfiguration {
     @ConditionalOnProperty(name = "nrich.webmvc.controller-advice-enabled", havingValue = "true", matchIfMissing = true)
     @Bean
     public NotificationErrorHandlingRestControllerAdvice notificationRestControllerAdvice(NrichWebMvcProperties webMvcProperties, NotificationResponseService<?> notificationResponseService,
-                                                                                          LoggingService loggingService,
-                                                                                          @Autowired(required = false) ExceptionAuxiliaryDataResolverService exceptionAuxiliaryDataResolverService,
-                                                                                          ExceptionHttpStatusResolverService exceptionHttpStatusResolverService) {
+                                                                                          LoggingService loggingService, ExceptionHttpStatusResolverService exceptionHttpStatusResolverService,
+                                                                                          @Autowired(required = false) ExceptionAuxiliaryDataResolverService exceptionAuxiliaryDataResolverService) {
         return new NotificationErrorHandlingRestControllerAdvice(
             webMvcProperties.getExceptionToUnwrapList(), webMvcProperties.getExceptionAuxiliaryDataToIncludeInNotification(), notificationResponseService, loggingService,
             exceptionAuxiliaryDataResolverService, exceptionHttpStatusResolverService
@@ -64,6 +64,7 @@ public class NrichWebMvcAutoConfiguration {
     }
 
     @ConditionalOnPropertyNotEmpty("nrich.webmvc.allowed-locale-list")
+    @ConditionalOnMissingBean
     @Bean
     public ConstrainedSessionLocaleResolver constrainedSessionLocaleResolver(NrichWebMvcProperties webMvcProperties) {
         return new ConstrainedSessionLocaleResolver(webMvcProperties.getDefaultLocale(), webMvcProperties.getAllowedLocaleList());


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.2.1
* Module:
Project

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description
Some *AutoConfiguration classes are missing @ConditionalOnMissingBean annotations on some beans. Add where missing and appropriate.
### Summary

Added @ConditionalOnMissingBean on beans where it was missing, add servlet restriction to registry controllers @ConditionalOnWebApplication annotation.

### Details

Added @ConditionalOnMissingBean on beans where it was missing, add servlet restriction to registry controllers @ConditionalOnWebApplication annotation.

### Related issue

https://github.com/croz-ltd/nrich/issues/34

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
