### PR TITLE
Feature support customising path in controllers

### DIFF
--- a/nrich-form-configuration/build.gradle
+++ b/nrich-form-configuration/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   testImplementation "org.glassfish:jakarta.el"
   testImplementation "org.hibernate.validator:hibernate-validator"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.jupiter:junit-jupiter-params"
   testImplementation "org.mockito:mockito-junit-jupiter"
   testImplementation "org.springframework:spring-test"
 }

--- a/nrich-form-configuration/src/main/java/net/croz/nrich/formconfiguration/controller/FormConfigurationController.java
+++ b/nrich-form-configuration/src/main/java/net/croz/nrich/formconfiguration/controller/FormConfigurationController.java
@@ -13,7 +13,7 @@ import javax.validation.Valid;
 import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("nrich/form/configuration")
+@RequestMapping("${nrich.form-configuration.endpoint-path:nrich/form/configuration}")
 public class FormConfigurationController {
 
     private final FormConfigurationService formConfigurationService;

--- a/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/controller/FormConfigurationControllerTest.java
+++ b/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/controller/FormConfigurationControllerTest.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import net.croz.nrich.formconfiguration.api.model.FormConfiguration;
 import net.croz.nrich.formconfiguration.api.request.FetchFormConfigurationRequest;
 import net.croz.nrich.formconfiguration.api.service.FormConfigurationService;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -37,23 +37,19 @@ class FormConfigurationControllerTest {
     @InjectMocks
     private FormConfigurationController formConfigurationController;
 
-    private MockMvc mockMvc;
-
-    @BeforeEach
-    void setup() {
-        mockMvc = MockMvcBuilders.standaloneSetup(formConfigurationController).build();
-    }
-
-    @Test
-    void shouldReturnFormConfiguration() throws Exception {
+    @CsvSource({ ",/nrich/form/configuration/fetch", "/api/form/configuration,/api/form/configuration/fetch" })
+    @ParameterizedTest
+    void shouldReturnFormConfiguration(String endpointPath, String uri) throws Exception {
         // given
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(formConfigurationController).addPlaceholderValue("nrich.form-configuration.endpoint-path", endpointPath).build();
+
         FetchFormConfigurationRequest request = createFetchFormConfigurationRequest();
         FormConfiguration formConfiguration = createFormConfiguration();
 
         doReturn(Collections.singletonList(formConfiguration)).when(formConfigurationService).fetchFormConfigurationList(request.getFormIdList());
 
         // when
-        MockHttpServletResponse response = mockMvc.perform(post("/nrich/form/configuration/fetch")
+        MockHttpServletResponse response = mockMvc.perform(post(uri)
             .content(objectMapper.writeValueAsString(request)).accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
 

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/configuration/controller/RegistryConfigurationController.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/configuration/controller/RegistryConfigurationController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("${croz.nrich.registry.domain:}/nrich/registry/configuration")
+@RequestMapping("${nrich.registry.configuration.endpoint-path:nrich/registry/configuration}")
 @ResponseBody
 public class RegistryConfigurationController {
 

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/data/controller/RegistryDataController.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/data/controller/RegistryDataController.java
@@ -23,7 +23,7 @@ import javax.validation.Valid;
 import java.util.Map;
 
 @RequiredArgsConstructor
-@RequestMapping("${croz.nrich.registry.domain:}/nrich/registry/data")
+@RequestMapping("${nrich.registry.data.endpoint-path:nrich/registry/data}")
 @ResponseBody
 public class RegistryDataController {
 

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/history/controller/RegistryHistoryController.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/history/controller/RegistryHistoryController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import javax.validation.Valid;
 
 @RequiredArgsConstructor
-@RequestMapping("${croz.nrich.registry.domain:}/nrich/registry/history")
+@RequestMapping("${nrich.registry.history.endpoint-path:nrich/registry/history}")
 @ResponseBody
 public class RegistryHistoryController {
 

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/configuration/controller/RegistryConfigurationControllerEndpointTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/configuration/controller/RegistryConfigurationControllerEndpointTest.java
@@ -10,13 +10,13 @@ import org.springframework.test.context.TestPropertySource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
-@TestPropertySource(locations = "/application-test.yml")
+@TestPropertySource(properties = "nrich.registry.configuration.endpoint-path=api/registry/configuration")
 class RegistryConfigurationControllerEndpointTest extends BaseWebTest {
 
     @Test
     void shouldFetchRegistryConfiguration() throws Exception {
         // when
-        MockHttpServletResponse response = mockMvc.perform(post("/domain/nrich/registry/configuration/fetch").contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
+        MockHttpServletResponse response = mockMvc.perform(post("/api/registry/configuration/fetch").contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
 
         // then
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/controller/RegistryDataControllerEndpointTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/controller/RegistryDataControllerEndpointTest.java
@@ -13,7 +13,7 @@ import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.c
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
-@TestPropertySource(locations = "/application-test.yml")
+@TestPropertySource(properties = "nrich.registry.data.endpoint-path=api/registry/data")
 class RegistryDataControllerEndpointTest extends BaseWebTest {
 
     @Test
@@ -23,7 +23,7 @@ class RegistryDataControllerEndpointTest extends BaseWebTest {
 
         // when
         MockHttpServletResponse response = mockMvc.perform(
-            post("/domain/nrich/registry/data/list").contentType(MediaType.APPLICATION_JSON)
+            post("/api/registry/data/list").contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))).andReturn().getResponse();
 
         // then

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/history/controller/RegistryHistoryControllerEndpointTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/history/controller/RegistryHistoryControllerEndpointTest.java
@@ -13,7 +13,7 @@ import static net.croz.nrich.registry.history.testutil.RegistryHistoryGenerating
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
-@TestPropertySource(locations = "/application-test.yml")
+@TestPropertySource(properties = "nrich.registry.history.endpoint-path=api/registry/history")
 class RegistryHistoryControllerEndpointTest extends BaseWebTest {
 
     @Test
@@ -22,7 +22,7 @@ class RegistryHistoryControllerEndpointTest extends BaseWebTest {
         ListRegistryHistoryRequest request = listRegistryHistoryRequest(RegistryHistoryTestEntity.class.getName(), 1L);
 
         // when
-        MockHttpServletResponse response = mockMvc.perform(post("/domain/nrich/registry/history/list")
+        MockHttpServletResponse response = mockMvc.perform(post("/api/registry/history/list")
             .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(request))).andReturn().getResponse();
 
         // then

--- a/nrich-registry/src/test/resources/application-test.yml
+++ b/nrich-registry/src/test/resources/application-test.yml
@@ -1,1 +1,0 @@
-croz.nrich.registry.domain: domain

--- a/nrich-security-csrf-spring-boot-starter/src/main/java/net/croz/nrich/security/csrf/configuration/NrichCsrfAutoConfiguration.java
+++ b/nrich-security-csrf-spring-boot-starter/src/main/java/net/croz/nrich/security/csrf/configuration/NrichCsrfAutoConfiguration.java
@@ -1,7 +1,6 @@
 package net.croz.nrich.security.csrf.configuration;
 
 import net.croz.nrich.security.csrf.api.service.CsrfTokenManagerService;
-import net.croz.nrich.security.csrf.core.constants.CsrfConstants;
 import net.croz.nrich.security.csrf.core.controller.CsrfPingController;
 import net.croz.nrich.security.csrf.core.service.AesCsrfTokenManagerService;
 import net.croz.nrich.security.csrf.properties.NrichCsrfProperties;
@@ -28,7 +27,7 @@ public class NrichCsrfAutoConfiguration {
         return new AesCsrfTokenManagerService(csrfProperties.getTokenExpirationInterval(), csrfProperties.getTokenFutureThreshold(), csrfProperties.getCryptoKeyLength());
     }
 
-    @ConditionalOnProperty(name = "nrich.security.csrf.csrf-ping-url", havingValue = CsrfConstants.CSRF_DEFAULT_PING_URI, matchIfMissing = true)
+    @ConditionalOnMissingBean
     @Bean
     public CsrfPingController csrfPingController() {
         return new CsrfPingController();

--- a/nrich-security-csrf/src/main/java/net/croz/nrich/security/csrf/core/controller/CsrfPingController.java
+++ b/nrich-security-csrf/src/main/java/net/croz/nrich/security/csrf/core/controller/CsrfPingController.java
@@ -15,7 +15,7 @@ public class CsrfPingController {
 
     private static final String SUCCESS_KEY = "success";
 
-    @RequestMapping(CsrfConstants.CSRF_DEFAULT_PING_URI)
+    @RequestMapping("${nrich.security.csrf.endpoint-path:" + CsrfConstants.CSRF_DEFAULT_PING_URI + "}")
     @ResponseBody
     public Map<String, Boolean> ping() {
         Map<String, Boolean> result = new HashMap<>();

--- a/nrich-security-csrf/src/test/java/net/croz/nrich/security/csrf/core/controller/CsrfPingControllerTest.java
+++ b/nrich-security-csrf/src/test/java/net/croz/nrich/security/csrf/core/controller/CsrfPingControllerTest.java
@@ -1,7 +1,7 @@
 package net.croz.nrich.security.csrf.core.controller;
 
-import net.croz.nrich.security.csrf.core.constants.CsrfConstants;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -13,12 +13,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 class CsrfPingControllerTest {
 
-    private final MockMvc mockMvc = MockMvcBuilders.standaloneSetup(CsrfPingController.class).build();
+    @CsvSource({ ",/nrich/csrf/ping", "/api/csrf/ping,/api/csrf/ping" })
+    @ParameterizedTest
+    void shouldReturnPingRequest(String endpointPath, String uri) throws Exception {
+        // given
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(CsrfPingController.class).addPlaceholderValue("nrich.security.csrf.endpoint-path", endpointPath).build();
 
-    @Test
-    void shouldReturnPingRequest() throws Exception {
         // when
-        MockHttpServletResponse response = mockMvc.perform(post(CsrfConstants.CSRF_DEFAULT_PING_URI).accept(MediaType.APPLICATION_JSON)
+        MockHttpServletResponse response = mockMvc.perform(post(uri).accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)).andReturn().getResponse();
 
         // then


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.2.1
* Module:
nrich-form-configuration, nrich-registry, nrich-security-csrf
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description
It would be useful to allow customising path (RequestMapping) in all controllers.
### Summary

Add support for customising path, changed the previous implementation in nrich-registry to allow for specifying full path.

### Details

Add support for customising path, changed the previous implementation in nrich-registry to allow for specifying full path.

### Related issue

https://github.com/croz-ltd/nrich/issues/38

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->



- Breaking change (fix, enhancement or feature that would cause existing functionality to change in backward-incompatible way)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- ~~I have updated the documentation accordingly~~ (documentation is not yet merged so currently it is not done)
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
