### PR TITLE
Feature use output stream instead of file in excel module

### DIFF
--- a/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/generator/ExcelReportGenerator.java
+++ b/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/generator/ExcelReportGenerator.java
@@ -13,8 +13,8 @@ public interface ExcelReportGenerator {
     void writeRowData(Object... reportDataList);
 
     /**
-     * Flushes data to report and closes it. No further writing is possible after this call.
+     * Flushes data to report (the OutputStream is not closed that's the user responsibility). No further writing is possible after this call.
      */
-    void flushAndClose();
+    void flush();
 
 }

--- a/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/request/CreateExcelReportRequest.java
+++ b/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/request/CreateExcelReportRequest.java
@@ -6,7 +6,7 @@ import net.croz.nrich.excel.api.model.ColumnDataFormat;
 import net.croz.nrich.excel.api.model.MultiRowDataProvider;
 import net.croz.nrich.excel.api.model.TemplateVariable;
 
-import java.io.File;
+import java.io.OutputStream;
 import java.util.List;
 
 @Getter
@@ -14,9 +14,9 @@ import java.util.List;
 public class CreateExcelReportRequest {
 
     /**
-     * File where report will be written to.
+     * OutputStream where report will be written to (keep in mind closing of it is users responsibility).
      */
-    private final File outputFile;
+    private final OutputStream outputStream;
 
     /**
      * Path to template (template is resolved from this path using Springs ResourceLoader)

--- a/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/request/CreateReportGeneratorRequest.java
+++ b/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/request/CreateReportGeneratorRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import net.croz.nrich.excel.api.model.ColumnDataFormat;
 import net.croz.nrich.excel.api.model.TemplateVariable;
 
-import java.io.File;
+import java.io.OutputStream;
 import java.util.List;
 
 @Getter
@@ -13,9 +13,9 @@ import java.util.List;
 public class CreateReportGeneratorRequest {
 
     /**
-     * File where report will be written to.
+     * OutputStream where report will be written to (keep in mind closing of it is users responsibility).
      */
-    private final File outputFile;
+    private final OutputStream outputStream;
 
     /**
      * Path to template (template is resolved from this path using Springs ResourceLoader)

--- a/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/service/ExcelReportService.java
+++ b/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/service/ExcelReportService.java
@@ -2,19 +2,16 @@ package net.croz.nrich.excel.api.service;
 
 import net.croz.nrich.excel.api.request.CreateExcelReportRequest;
 
-import java.io.File;
-
 /**
- * Creates and writes excel report to a file.
+ * Creates and writes excel report to the provided OutputStream.
  */
 public interface ExcelReportService {
 
     /**
-     * Returns file with excel report data written to it.
+     * Writes the excel report to  the provided OutputStream.
      *
      * @param request configuration options for excel report with data to be written
-     * @return file with excel report
      */
-    File createExcelReport(CreateExcelReportRequest request);
+    void createExcelReport(CreateExcelReportRequest request);
 
 }

--- a/nrich-excel/README.md
+++ b/nrich-excel/README.md
@@ -5,7 +5,7 @@
 ## Overview
 
 nrich-excel is a library intended to simplify excel report generation for simple reports (i.e. exporting search results). It uses Apache POI library for excel creation. Excel reports are generated
-from templates (standard excel files) and library also supports template variable resolving.
+from templates (standard excel files) and library also supports template variable resolving. The data is written to a provided OutputStream (users are expected to close it, library doesn't close it).
 
 ## Setting up Spring beans
 
@@ -45,7 +45,7 @@ that uses Apache POI library for writing data.
 
 ## Usage
 
-To be able to create reports users should inject `ExcelReportService` and call `File createExcelReport(CreateExcelReportRequest request)`
+To be able to create reports users should inject `ExcelReportService` and call `void createExcelReport(CreateExcelReportRequest request)`
 method.
 
 Method accepts argument of type `CreateExcelReportRequest` when processing report `ExcelReportService` will then call `Object[][] resolveMultiRowData(int start, int limit)` method
@@ -103,9 +103,12 @@ Example usage of `ExcelReportService` is:
     // data format for columns 2 and 3 is overriden one date is written with dd-MM-yyyy format and another with dd-MM-yyyy HH:mm format
     List<ColumnDataFormat> columnDataFormatList = Arrays.asList(new ColumnDataFormat(2, "dd-MM-yyyy"), new ColumnDataFormat(3, "dd-MM-yyyy HH:mm"));
 
-    // first row index is 3 since first two rows contain column headers
-    CreateExcelReportRequest request = CreateExcelReportRequest.builder().templateVariableList(templateVariableList).columnDataFormatList(columnDataFormatList).multiRowDataProvider(multiRowDataProvider).batchSize(10).outputFile(file).templatePath("classpath:excel/template.xlsx").firstRowIndex(3).build();
+    try (FileOutputStream outputStream = new FileOutputStream(file)) {
+        // first row index is 3 since first two rows contain column headers
+        CreateExcelReportRequest request = CreateExcelReportRequest.builder().templateVariableList(templateVariableList).columnDataFormatList(columnDataFormatList).multiRowDataProvider(multiRowDataProvider).batchSize(10).outputStream(outputStream).templatePath("classpath:excel/template.xlsx").firstRowIndex(3).build();
 
-    File createdFile = ExcelReportService.createExcelReport(request);
+        excelReportService.createExcelReport(request);
+    }
+
 
 ```

--- a/nrich-excel/src/main/java/net/croz/nrich/excel/generator/PoiExcelReportGenerator.java
+++ b/nrich-excel/src/main/java/net/croz/nrich/excel/generator/PoiExcelReportGenerator.java
@@ -16,9 +16,8 @@ import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.util.Assert;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,7 @@ public class PoiExcelReportGenerator implements ExcelReportGenerator {
 
     private final List<CellValueConverter> cellValueConverterList;
 
-    private final File outputFile;
+    private final OutputStream outputStream;
 
     private final SXSSFWorkbook workbook;
 
@@ -50,10 +49,10 @@ public class PoiExcelReportGenerator implements ExcelReportGenerator {
 
     private boolean templateOpen = true;
 
-    public PoiExcelReportGenerator(List<CellValueConverter> cellValueConverterList, File outputFile, InputStream template, List<TemplateVariable> templateVariableList,
+    public PoiExcelReportGenerator(List<CellValueConverter> cellValueConverterList, OutputStream outputStream, InputStream template, List<TemplateVariable> templateVariableList,
                                    List<TypeDataFormat> typeDataFormatList, List<ColumnDataFormat> columnDataFormatList, int startIndex) {
         this.cellValueConverterList = cellValueConverterList;
-        this.outputFile = outputFile;
+        this.outputStream = outputStream;
         this.workbook = initializeWorkBookWithTemplate(template, templateVariableList);
         this.sheet = workbook.getSheetAt(0);
         this.creationHelper = workbook.getCreationHelper();
@@ -80,10 +79,8 @@ public class PoiExcelReportGenerator implements ExcelReportGenerator {
 
     @SneakyThrows
     @Override
-    public void flushAndClose() {
-        try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
-            workbook.write(outputStream);
-        }
+    public void flush() {
+        workbook.write(outputStream);
         this.templateOpen = false;
     }
 

--- a/nrich-excel/src/main/java/net/croz/nrich/excel/generator/PoiExcelReportGenerator.java
+++ b/nrich-excel/src/main/java/net/croz/nrich/excel/generator/PoiExcelReportGenerator.java
@@ -63,7 +63,7 @@ public class PoiExcelReportGenerator implements ExcelReportGenerator {
 
     @Override
     public void writeRowData(Object... reportDataList) {
-        Assert.isTrue(templateOpen, "Template has benn closed and cannot be written anymore");
+        Assert.isTrue(templateOpen, "Template has been closed and cannot be written anymore");
 
         Row row = sheet.createRow(currentRowNumber++);
 

--- a/nrich-excel/src/main/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorFactory.java
+++ b/nrich-excel/src/main/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorFactory.java
@@ -24,14 +24,14 @@ public class PoiExcelReportGeneratorFactory implements ExcelReportGeneratorFacto
 
     @Override
     public ExcelReportGenerator createReportGenerator(CreateReportGeneratorRequest request) {
-        Assert.isTrue(request.getOutputFile() != null && request.getOutputFile().exists(), "Output file cannot be null");
+        Assert.isTrue(request.getOutputStream() != null, "OutputStream cannot be null");
         Assert.hasText(request.getTemplatePath(), "Template path cannot be null");
         Assert.isTrue(request.getFirstRowIndex() >= 0, "Row index must be greater or equal to 0");
 
         InputStream template = resolveTemplate(request.getTemplatePath());
 
         return new PoiExcelReportGenerator(
-            cellValueConverterList, request.getOutputFile(), template, request.getTemplateVariableList(), typeDataFormatList, request.getColumnDataFormatList(), request.getFirstRowIndex()
+            cellValueConverterList, request.getOutputStream(), template, request.getTemplateVariableList(), typeDataFormatList, request.getColumnDataFormatList(), request.getFirstRowIndex()
         );
     }
 

--- a/nrich-excel/src/main/java/net/croz/nrich/excel/service/DefaultExcelReportService.java
+++ b/nrich-excel/src/main/java/net/croz/nrich/excel/service/DefaultExcelReportService.java
@@ -9,7 +9,6 @@ import net.croz.nrich.excel.api.request.CreateReportGeneratorRequest;
 import net.croz.nrich.excel.api.service.ExcelReportService;
 import org.springframework.util.Assert;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -19,7 +18,7 @@ public class DefaultExcelReportService implements ExcelReportService {
     private final ExcelReportGeneratorFactory excelReportGeneratorFactory;
 
     @Override
-    public File createExcelReport(CreateExcelReportRequest request) {
+    public void createExcelReport(CreateExcelReportRequest request) {
         Assert.notNull(request.getMultiRowDataProvider(), "Row data provider cannot be null!");
         Assert.isTrue(request.getBatchSize() > 0, "Batch size must be greater than zero!");
 
@@ -44,16 +43,14 @@ public class DefaultExcelReportService implements ExcelReportService {
             start += limit;
         }
 
-        excelReportGenerator.flushAndClose();
-
-        return request.getOutputFile();
+        excelReportGenerator.flush();
     }
 
     private CreateReportGeneratorRequest toCreateReportGeneratorRequest(CreateExcelReportRequest reportRequest) {
         return CreateReportGeneratorRequest.builder()
             .columnDataFormatList(reportRequest.getColumnDataFormatList())
             .firstRowIndex(reportRequest.getFirstRowIndex())
-            .outputFile(reportRequest.getOutputFile())
+            .outputStream(reportRequest.getOutputStream())
             .templatePath(reportRequest.getTemplatePath())
             .templateVariableList(reportRequest.getTemplateVariableList())
             .build();

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorFactoryTest.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorFactoryTest.java
@@ -1,16 +1,14 @@
 package net.croz.nrich.excel.generator;
 
-import lombok.SneakyThrows;
 import net.croz.nrich.excel.ExcelTestConfiguration;
 import net.croz.nrich.excel.api.generator.ExcelReportGenerator;
 import net.croz.nrich.excel.api.request.CreateReportGeneratorRequest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.util.Assert;
 
-import java.io.File;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -21,9 +19,6 @@ class PoiExcelReportGeneratorFactoryTest {
     @Autowired
     private PoiExcelReportGeneratorFactory excelReportGeneratorFactory;
 
-    @TempDir
-    File temporaryDirectory;
-
     @Test
     void shouldThrowExceptionWhenOutputFileDoesntExist() {
         // given
@@ -33,55 +28,45 @@ class PoiExcelReportGeneratorFactoryTest {
         Throwable thrown = catchThrowable(() -> excelReportGeneratorFactory.createReportGenerator(request));
 
         // then
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage("OutputStream cannot be null");
     }
 
     @Test
     void shouldThrowExceptionWhenTemplateFileDoesntExist() {
         // given
-        CreateReportGeneratorRequest request = CreateReportGeneratorRequest.builder().outputFile(new File(temporaryDirectory, "output.xlsx")).build();
+        OutputStream outputStream = new ByteArrayOutputStream();
+        CreateReportGeneratorRequest request = CreateReportGeneratorRequest.builder().outputStream(outputStream).build();
 
         // when
         Throwable thrown = catchThrowable(() -> excelReportGeneratorFactory.createReportGenerator(request));
 
         // then
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage("Template path cannot be null");
     }
 
     @Test
     void shouldThrowExceptionWhenRowIndexIsNegative() {
         // given
-        File file = createFileInTemporaryDirectory("missing-row.xlxs");
-
-        CreateReportGeneratorRequest request = CreateReportGeneratorRequest.builder().outputFile(file).templatePath("classpath:excel/template.xlsx").firstRowIndex(-1).build();
+        OutputStream outputStream = new ByteArrayOutputStream();
+        CreateReportGeneratorRequest request = CreateReportGeneratorRequest.builder().outputStream(outputStream).templatePath("classpath:excel/template.xlsx").firstRowIndex(-1).build();
 
         // when
         Throwable thrown = catchThrowable(() -> excelReportGeneratorFactory.createReportGenerator(request));
 
         // then
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage("Row index must be greater or equal to 0");
     }
 
     @Test
     void shouldReturnReportGeneratorWhenDataIsValid() {
         // given
-        File file = createFileInTemporaryDirectory("valid.xlxs");
-
-        CreateReportGeneratorRequest request = CreateReportGeneratorRequest.builder().outputFile(file).templatePath("classpath:excel/template.xlsx").firstRowIndex(1).build();
+        OutputStream outputStream = new ByteArrayOutputStream();
+        CreateReportGeneratorRequest request = CreateReportGeneratorRequest.builder().outputStream(outputStream).templatePath("classpath:excel/template.xlsx").firstRowIndex(1).build();
 
         // when
         ExcelReportGenerator excelReportGenerator = excelReportGeneratorFactory.createReportGenerator(request);
 
         // then
         assertThat(excelReportGenerator).isNotNull();
-    }
-
-    @SneakyThrows
-    private File createFileInTemporaryDirectory(String fileName) {
-        File file = new File(temporaryDirectory, fileName);
-
-        Assert.isTrue(file.createNewFile(), "File has not been created for test");
-
-        return file;
     }
 }

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorTest.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorTest.java
@@ -100,7 +100,7 @@ class PoiExcelReportGeneratorTest {
         Throwable thrown = catchThrowable(() -> excelReportGenerator.writeRowData(rowData));
 
         // then
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage("Template has benn closed and cannot be written anymore");
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage("Template has been closed and cannot be written anymore");
     }
 
     @Test

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorTest.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorTest.java
@@ -9,9 +9,8 @@ import net.croz.nrich.excel.util.TypeDataFormatUtil;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -35,14 +34,11 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 class PoiExcelReportGeneratorTest {
 
-    private static final String REPORT_FILE_NAME = "report.xlsx";
-
     private static final int TEMPLATE_DATA_FIRST_ROW_INDEX = 3;
 
     private PoiExcelReportGenerator excelReportGenerator;
 
-    @TempDir
-    File temporaryDirectory;
+    private ByteArrayOutputStream outputStream;
 
     static {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
@@ -59,8 +55,10 @@ class PoiExcelReportGeneratorTest {
             "dd.MM.yyyy.", "dd.MM.yyyy. HH:mm", "#,##0", "#,##0.00", true, additionalFormatList
         );
 
+        outputStream = new ByteArrayOutputStream();
+
         excelReportGenerator = new PoiExcelReportGenerator(
-            cellValueConverterList, new File(temporaryDirectory, REPORT_FILE_NAME), template, templateVariableList, typeDataFormatList, columnDataFormatList, TEMPLATE_DATA_FIRST_ROW_INDEX
+            cellValueConverterList, outputStream, template, templateVariableList, typeDataFormatList, columnDataFormatList, TEMPLATE_DATA_FIRST_ROW_INDEX
         );
     }
 
@@ -77,10 +75,10 @@ class PoiExcelReportGeneratorTest {
 
         // when
         excelReportGenerator.writeRowData(rowData);
-        excelReportGenerator.flushAndClose();
+        excelReportGenerator.flush();
 
         // and when
-        Sheet sheet = createWorkbookAndResolveSheet(new File(temporaryDirectory, REPORT_FILE_NAME));
+        Sheet sheet = createWorkbookAndResolveSheet(outputStream);
 
         // then
         assertThat(sheet).isNotNull();
@@ -96,13 +94,13 @@ class PoiExcelReportGeneratorTest {
         Object[] rowData = new Object[] { 1.0, "value", Instant.now().truncatedTo(ChronoUnit.DAYS), Instant.now().truncatedTo(ChronoUnit.DAYS) };
 
         excelReportGenerator.writeRowData(rowData);
-        excelReportGenerator.flushAndClose();
+        excelReportGenerator.flush();
 
         // when
         Throwable thrown = catchThrowable(() -> excelReportGenerator.writeRowData(rowData));
 
         // then
-        assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage("Template has benn closed and cannot be written anymore");
     }
 
     @Test
@@ -113,10 +111,10 @@ class PoiExcelReportGeneratorTest {
 
         // when
         excelReportGenerator.writeRowData(rowData);
-        excelReportGenerator.flushAndClose();
+        excelReportGenerator.flush();
 
         // and when
-        Sheet sheet = createWorkbookAndResolveSheet(new File(temporaryDirectory, REPORT_FILE_NAME));
+        Sheet sheet = createWorkbookAndResolveSheet(outputStream);
 
         // then
         assertThat(getRowCellStyleList(sheet.getRow(TEMPLATE_DATA_FIRST_ROW_INDEX))).containsExactly(

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/testutil/ExcelReportRequestGeneratingUtil.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/testutil/ExcelReportRequestGeneratingUtil.java
@@ -1,26 +1,28 @@
 package net.croz.nrich.excel.testutil;
 
+import lombok.SneakyThrows;
 import net.croz.nrich.excel.api.model.MultiRowDataProvider;
 import net.croz.nrich.excel.api.request.CreateExcelReportRequest;
 
-import java.io.File;
+import java.io.OutputStream;
 
 public final class ExcelReportRequestGeneratingUtil {
 
     private ExcelReportRequestGeneratingUtil() {
     }
 
-    public static CreateExcelReportRequest createExcelReportRequest(Object[][] rowData, int batchSize, File file, int firstRowIndex) {
+    public static CreateExcelReportRequest createExcelReportRequest(Object[][] rowData, int batchSize, OutputStream outputStream, int firstRowIndex) {
         MultiRowDataProvider multiRowDataProvider = (start, limit) -> start == 0 ? rowData : null;
 
-        return createExcelReportRequest(rowData == null ? null : multiRowDataProvider, batchSize, file, firstRowIndex);
+        return createExcelReportRequest(rowData == null ? null : multiRowDataProvider, batchSize, outputStream, firstRowIndex);
     }
 
-    public static CreateExcelReportRequest createExcelReportRequest(MultiRowDataProvider multiRowDataProvider, int batchSize, File file, int firstRowIndex) {
+    @SneakyThrows
+    public static CreateExcelReportRequest createExcelReportRequest(MultiRowDataProvider multiRowDataProvider, int batchSize, OutputStream outputStream, int firstRowIndex) {
         return CreateExcelReportRequest.builder()
             .multiRowDataProvider(multiRowDataProvider)
             .batchSize(batchSize)
-            .outputFile(file)
+            .outputStream(outputStream)
             .templatePath("classpath:excel/template.xlsx")
             .firstRowIndex(firstRowIndex).build();
     }

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/testutil/PoiDataResolverUtil.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/testutil/PoiDataResolverUtil.java
@@ -5,10 +5,10 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
-import java.io.File;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,11 +61,7 @@ public final class PoiDataResolverUtil {
     }
 
     @SneakyThrows
-    public static Sheet createWorkbookAndResolveSheet(File file) {
-        // it is necessary to close the workbook, i.e. unlock the file, in order to avoid an IOException (on some OSs)
-        // in case the file is inside a @TempDir which gets automatically deleted afterwards
-        try (Workbook workbook = new XSSFWorkbook(file)) {
-            return workbook.getSheetAt(0);
-        }
+    public static Sheet createWorkbookAndResolveSheet(ByteArrayOutputStream outputStream) {
+        return new XSSFWorkbook(new ByteArrayInputStream(outputStream.toByteArray())).getSheetAt(0);
     }
 }


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
  <!-- released version or snapshot version -->
* Module:
nrich-excel

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description
Changes nrich-excel API to use OutputStream instead of File.
### Summary
Changed nrich-excel API to accept OutputStream, simplified tests to use ByteArrayOutputStream (thus avoiding the need for creating temporary files).
### Details

Changed nrich-excel API to accept OutputStream, simplified tests to use ByteArrayOutputStream (thus avoiding the need for creating temporary files)
### Related issue
https://github.com/croz-ltd/nrich/issues/44
## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Breaking change (fix, enhancement or feature that would cause existing functionality to change in backward-incompatible way)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
