### PR TITLE
Feature easier initialisation of flat data for excel report

### DIFF
--- a/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/request/CreateExcelReportRequest.java
+++ b/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/request/CreateExcelReportRequest.java
@@ -48,4 +48,27 @@ public class CreateExcelReportRequest {
      */
     private final MultiRowDataProvider multiRowDataProvider;
 
+    /**
+     * Creates {@link CreateExcelReportRequest} Builder instance from flat data.
+     *
+     * @param data Flat data to be written
+     * @return A {@link CreateExcelReportRequest} builder instance
+     */
+    public static CreateExcelReportRequest.CreateExcelReportRequestBuilder fromFlatData(Object[][] data) {
+        return CreateExcelReportRequest.builder().multiRowDataProvider((start, limit) -> start == 0 ? data : null);
+    }
+
+    /**
+     * Creates {@link CreateExcelReportRequest} Builder instance from {@link MultiRowDataProvider} instance.
+     *
+     * @param multiRowDataProvider Row provider for data to be written
+     * @return A {@link CreateExcelReportRequest} builder instance
+     */
+    public static CreateExcelReportRequest.CreateExcelReportRequestBuilder fromRowDataProvider(MultiRowDataProvider multiRowDataProvider) {
+        return CreateExcelReportRequest.builder().multiRowDataProvider(multiRowDataProvider);
+    }
+
+    private static CreateExcelReportRequest.CreateExcelReportRequestBuilder builder() {
+        return new CreateExcelReportRequest.CreateExcelReportRequestBuilder();
+    }
 }

--- a/nrich-excel/README.md
+++ b/nrich-excel/README.md
@@ -94,8 +94,6 @@ Example usage of `ExcelReportService` is:
     File file = new File("directory/excel-report.xlsx");
     // rows in excel
     Object[][] rowData = new Object[][] { { 1.1, "value 1", new Date(), new Date() }, { 2.2, "value 2", new Date(), new Date() };
-    // no need for batching since we have only two records
-    MultiRowDataProvider multiRowDataProvider = (start, limit) -> start == 0 ? rowData : null;
 
     // template variable defined in template with value ${templateVariable} will be replaced with resolvedValue
     List<TemplateVariable> templateVariableList = Collections.singletonList(new TemplateVariable("templateVariable", "resolvedValue"));
@@ -105,7 +103,7 @@ Example usage of `ExcelReportService` is:
 
     try (FileOutputStream outputStream = new FileOutputStream(file)) {
         // first row index is 3 since first two rows contain column headers
-        CreateExcelReportRequest request = CreateExcelReportRequest.builder().templateVariableList(templateVariableList).columnDataFormatList(columnDataFormatList).multiRowDataProvider(multiRowDataProvider).batchSize(10).outputStream(outputStream).templatePath("classpath:excel/template.xlsx").firstRowIndex(3).build();
+        CreateExcelReportRequest request = CreateExcelReportRequest.fromFlatData(rowData).templateVariableList(templateVariableList).columnDataFormatList(columnDataFormatList).batchSize(10).outputStream(outputStream).templatePath("classpath:excel/template.xlsx").firstRowIndex(3).build();
 
         excelReportService.createExcelReport(request);
     }

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/service/DefaultExcelReportServiceTest.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/service/DefaultExcelReportServiceTest.java
@@ -62,7 +62,7 @@ class DefaultExcelReportServiceTest {
     void shouldThrowExceptionOnMissingRowDataProvider() {
         // given
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        CreateExcelReportRequest request = createExcelReportRequest((Object[][]) null, 10, outputStream, TEMPLATE_DATA_FIRST_ROW_INDEX);
+        CreateExcelReportRequest request = createExcelReportRequest((MultiRowDataProvider) null, 10, outputStream, TEMPLATE_DATA_FIRST_ROW_INDEX);
 
         // when
         Throwable thrown = catchThrowable(() -> excelReportService.createExcelReport(request));

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/testutil/ExcelReportRequestGeneratingUtil.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/testutil/ExcelReportRequestGeneratingUtil.java
@@ -1,6 +1,5 @@
 package net.croz.nrich.excel.testutil;
 
-import lombok.SneakyThrows;
 import net.croz.nrich.excel.api.model.MultiRowDataProvider;
 import net.croz.nrich.excel.api.request.CreateExcelReportRequest;
 
@@ -8,22 +7,24 @@ import java.io.OutputStream;
 
 public final class ExcelReportRequestGeneratingUtil {
 
+    private static final String TEMPLATE_PATH = "classpath:excel/template.xlsx";
+
     private ExcelReportRequestGeneratingUtil() {
     }
 
     public static CreateExcelReportRequest createExcelReportRequest(Object[][] rowData, int batchSize, OutputStream outputStream, int firstRowIndex) {
-        MultiRowDataProvider multiRowDataProvider = (start, limit) -> start == 0 ? rowData : null;
-
-        return createExcelReportRequest(rowData == null ? null : multiRowDataProvider, batchSize, outputStream, firstRowIndex);
-    }
-
-    @SneakyThrows
-    public static CreateExcelReportRequest createExcelReportRequest(MultiRowDataProvider multiRowDataProvider, int batchSize, OutputStream outputStream, int firstRowIndex) {
-        return CreateExcelReportRequest.builder()
-            .multiRowDataProvider(multiRowDataProvider)
+        return CreateExcelReportRequest.fromFlatData(rowData)
             .batchSize(batchSize)
             .outputStream(outputStream)
-            .templatePath("classpath:excel/template.xlsx")
+            .templatePath(TEMPLATE_PATH)
+            .firstRowIndex(firstRowIndex).build();
+    }
+
+    public static CreateExcelReportRequest createExcelReportRequest(MultiRowDataProvider multiRowDataProvider, int batchSize, OutputStream outputStream, int firstRowIndex) {
+        return CreateExcelReportRequest.fromRowDataProvider(multiRowDataProvider)
+            .batchSize(batchSize)
+            .outputStream(outputStream)
+            .templatePath(TEMPLATE_PATH)
             .firstRowIndex(firstRowIndex).build();
     }
 }


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.2.1
* Module:
nrich-excel

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description
It would be good for users to be able to just specify flat data for excel without need for MultiRowDataProvider.
### Summary

Add static methods for creating builders for CreateExcelReportRequest, one for flat data and another for MultiRowDataProvider.

### Details

Add static methods for creating builders for CreateExcelReportRequest, one for flat data and another for MultiRowDataProvider.

### Related issue
https://github.com/croz-ltd/nrich/issues/30

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Breaking change (fix, enhancement or feature that would cause existing functionality to change in backward-incompatible way)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
