### PR TITLE
Add explicit builder class to CreateExcelReportRequest to avoid error…

### DIFF
--- a/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/request/CreateExcelReportRequest.java
+++ b/nrich-excel-api/src/main/java/net/croz/nrich/excel/api/request/CreateExcelReportRequest.java
@@ -68,6 +68,12 @@ public class CreateExcelReportRequest {
         return CreateExcelReportRequest.builder().multiRowDataProvider(multiRowDataProvider);
     }
 
+    /**
+     * CreateExcelReportRequest builder (explicit to avoid errors while publishing javadoc).
+     */
+    public static class CreateExcelReportRequestBuilder { // NOSONAR
+    }
+
     private static CreateExcelReportRequest.CreateExcelReportRequestBuilder builder() {
         return new CreateExcelReportRequest.CreateExcelReportRequestBuilder();
     }


### PR DESCRIPTION
…s while publising javadoc

<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.2.1
* Module:
nrich-excel-api

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Javadoc publishing fails since it cannot find Lomboks builder. Solution is to add an empty class for builder.

### Details

Javadoc publishing fails since it cannot find Lomboks builder. Solution is to add an empty class for builder.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
