### PR TITLE
Feature improve notification service generics

### DIFF
--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/response/NotificationDataResponse.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/response/NotificationDataResponse.java
@@ -1,0 +1,23 @@
+package net.croz.nrich.notification.api.response;
+
+import lombok.Getter;
+import net.croz.nrich.notification.api.model.Notification;
+
+/**
+ * Wrapper around response data that allows for sending notification with original response data.
+ *
+ * @param <T> type of response data
+ */
+@Getter
+public class NotificationDataResponse<T> extends NotificationResponse {
+
+    /**
+     * Response data
+     */
+    private final T data;
+
+    public NotificationDataResponse(Notification notification, T data) {
+        super(notification);
+        this.data = data;
+    }
+}

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/response/NotificationResponse.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/response/NotificationResponse.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import net.croz.nrich.notification.api.model.Notification;
 
 /**
- * Response that hold notification.
+ * Response that holds notification.
  */
 @RequiredArgsConstructor
 @Getter

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/response/NotificationResponse.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/response/NotificationResponse.java
@@ -5,18 +5,11 @@ import lombok.RequiredArgsConstructor;
 import net.croz.nrich.notification.api.model.Notification;
 
 /**
- * Wrapper around response data that allows for sending notification with original response data.
- *
- * @param <T> type of response data
+ * Response that hold notification.
  */
 @RequiredArgsConstructor
 @Getter
-public class ResponseWithNotification<T> {
-
-    /**
-     * Response data
-     */
-    private final T data;
+public class NotificationResponse {
 
     /**
      * Notification

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/BaseNotificationResponseService.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/BaseNotificationResponseService.java
@@ -46,23 +46,19 @@ public interface BaseNotificationResponseService<T> {
     /**
      * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
      *
-     * @param data                       data to include in response
+     * @param actionName                 name of the action for which to resolve notification
      * @param additionalNotificationData additional notification data to add to notification
-     * @param <D>                        type of data
      * @return response with notification
      */
-    <D> T responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData);
+    T responseWithNotification(String actionName, AdditionalNotificationData additionalNotificationData);
 
     /**
      * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
      *
-     * @param data                       data to include in response
-     * @param actionName                 name of the action for which to resolve notification
      * @param additionalNotificationData additional notification data to add to notification
-     * @param <D>                        type of data
      * @return response with notification
      */
-    <D> T responseWithNotification(D data, String actionName, AdditionalNotificationData additionalNotificationData);
+    T responseWithNotificationActionResolvedFromRequest(AdditionalNotificationData additionalNotificationData);
 
     NotificationResolverService notificationResolverService();
 
@@ -78,19 +74,11 @@ public interface BaseNotificationResponseService<T> {
         return responseWithExceptionNotification(throwable, AdditionalNotificationData.empty(), additionalMessageArgumentList);
     }
 
-    default <D> T responseWithNotificationActionResolvedFromRequest(D data) {
-        return responseWithNotificationActionResolvedFromRequest(data, AdditionalNotificationData.empty());
-    }
-
-    default <D> T responseWithNotification(D data, String actionName) {
-        return responseWithNotification(data, actionName, AdditionalNotificationData.empty());
-    }
-
     default T responseWithNotificationActionResolvedFromRequest() {
-        return responseWithNotificationActionResolvedFromRequest(null, AdditionalNotificationData.empty());
+        return responseWithNotificationActionResolvedFromRequest(AdditionalNotificationData.empty());
     }
 
     default T responseWithNotification(String actionName) {
-        return responseWithNotification(null, actionName, AdditionalNotificationData.empty());
+        return responseWithNotification(actionName, AdditionalNotificationData.empty());
     }
 }

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/BaseNotificationResponseService.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/BaseNotificationResponseService.java
@@ -8,7 +8,7 @@ import javax.validation.ConstraintViolationException;
 
 
 /**
- * Helper service that helps creation response with notification.
+ * Helper service for creation of response with notification.
  *
  * @param <T> Type of response with notification i.e. {@link NotificationDataResponse}
  */

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/BaseNotificationResponseService.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/BaseNotificationResponseService.java
@@ -1,0 +1,96 @@
+package net.croz.nrich.notification.api.service;
+
+import net.croz.nrich.notification.api.model.AdditionalNotificationData;
+import net.croz.nrich.notification.api.response.NotificationDataResponse;
+import org.springframework.validation.Errors;
+
+import javax.validation.ConstraintViolationException;
+
+
+/**
+ * Helper service that helps creation response with notification.
+ *
+ * @param <T> Type of response with notification i.e. {@link NotificationDataResponse}
+ */
+public interface BaseNotificationResponseService<T> {
+
+    /**
+     * Returns response with {@link net.croz.nrich.notification.api.model.ValidationFailureNotification} instance.
+     *
+     * @param errors                     Springs {@link Errors} that will be used to resolve validation notification messages.
+     * @param validationFailedOwningType class on which validation errors were found
+     * @param additionalNotificationData additional notification data to add to notification
+     * @return response with validation failure notification
+     */
+    T responseWithValidationFailureNotification(Errors errors, Class<?> validationFailedOwningType, AdditionalNotificationData additionalNotificationData);
+
+    /**
+     * Returns response with {@link net.croz.nrich.notification.api.model.ValidationFailureNotification} instance.
+     *
+     * @param exception                  validation exception that will be used to resolve validation notification messages.
+     * @param additionalNotificationData additional notification data to add to notification
+     * @return response with validation failure notification
+     */
+    T responseWithValidationFailureNotification(ConstraintViolationException exception, AdditionalNotificationData additionalNotificationData);
+
+    /**
+     * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
+     *
+     * @param throwable                    exception for which to resolve notification
+     * @param additionalNotificationData   additional notification data to add to notification
+     * @param exceptionMessageArgumentList optional exception argument list, will be used when resolving exception message
+     * @return response with notification
+     */
+    T responseWithExceptionNotification(Throwable throwable, AdditionalNotificationData additionalNotificationData, Object... exceptionMessageArgumentList);
+
+    /**
+     * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
+     *
+     * @param data                       data to include in response
+     * @param additionalNotificationData additional notification data to add to notification
+     * @param <D>                        type of data
+     * @return response with notification
+     */
+    <D> T responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData);
+
+    /**
+     * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
+     *
+     * @param data                       data to include in response
+     * @param actionName                 name of the action for which to resolve notification
+     * @param additionalNotificationData additional notification data to add to notification
+     * @param <D>                        type of data
+     * @return response with notification
+     */
+    <D> T responseWithNotification(D data, String actionName, AdditionalNotificationData additionalNotificationData);
+
+    NotificationResolverService notificationResolverService();
+
+    default T responseWithValidationFailureNotification(Errors errors, Class<?> validationFailedOwningType) {
+        return responseWithValidationFailureNotification(errors, validationFailedOwningType, AdditionalNotificationData.empty());
+    }
+
+    default T responseWithValidationFailureNotification(ConstraintViolationException exception) {
+        return responseWithValidationFailureNotification(exception, AdditionalNotificationData.empty());
+    }
+
+    default T responseWithExceptionNotification(Throwable throwable, Object... additionalMessageArgumentList) {
+        return responseWithExceptionNotification(throwable, AdditionalNotificationData.empty(), additionalMessageArgumentList);
+    }
+
+    default <D> T responseWithNotificationActionResolvedFromRequest(D data) {
+        return responseWithNotificationActionResolvedFromRequest(data, AdditionalNotificationData.empty());
+    }
+
+    default <D> T responseWithNotification(D data, String actionName) {
+        return responseWithNotification(data, actionName, AdditionalNotificationData.empty());
+    }
+
+    default T responseWithNotificationActionResolvedFromRequest() {
+        return responseWithNotificationActionResolvedFromRequest(null, AdditionalNotificationData.empty());
+    }
+
+    default T responseWithNotification(String actionName) {
+        return responseWithNotification(null, actionName, AdditionalNotificationData.empty());
+    }
+}

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/NotificationResponseService.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/NotificationResponseService.java
@@ -1,96 +1,24 @@
 package net.croz.nrich.notification.api.service;
 
 import net.croz.nrich.notification.api.model.AdditionalNotificationData;
-import org.springframework.validation.Errors;
+import net.croz.nrich.notification.api.response.NotificationDataResponse;
+import net.croz.nrich.notification.api.response.NotificationResponse;
 
-import javax.validation.ConstraintViolationException;
+public interface NotificationResponseService extends BaseNotificationResponseService<NotificationResponse> {
 
-// TODO maybe reduce number of methods, this seems a bit complicated?
+    @Override
+    <D> NotificationDataResponse<D> responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData);
 
-/**
- * Helper service that helps creation response with notification.
- *
- * @param <T> Type of response with notification i.e. {@link net.croz.nrich.notification.api.response.ResponseWithNotification}
- */
-public interface NotificationResponseService<T> {
+    @Override
+    <D> NotificationDataResponse<D> responseWithNotification(D data, String actionName, AdditionalNotificationData additionalNotificationData);
 
-    /**
-     * Returns response with {@link net.croz.nrich.notification.api.model.ValidationFailureNotification} instance.
-     *
-     * @param errors                     Springs {@link Errors} that will be used to resolve validation notification messages.
-     * @param validationFailedOwningType class on which validation errors were found
-     * @param additionalNotificationData additional notification data to add to notification
-     * @return response with validation failure notification
-     */
-    T responseWithValidationFailureNotification(Errors errors, Class<?> validationFailedOwningType, AdditionalNotificationData additionalNotificationData);
-
-    /**
-     * Returns response with {@link net.croz.nrich.notification.api.model.ValidationFailureNotification} instance.
-     *
-     * @param exception                  validation exception that will be used to resolve validation notification messages.
-     * @param additionalNotificationData additional notification data to add to notification
-     * @return response with validation failure notification
-     */
-    T responseWithValidationFailureNotification(ConstraintViolationException exception, AdditionalNotificationData additionalNotificationData);
-
-    /**
-     * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
-     *
-     * @param throwable                    exception for which to resolve notification
-     * @param additionalNotificationData   additional notification data to add to notification
-     * @param exceptionMessageArgumentList optional exception argument list, will be used when resolving exception message
-     * @return response with notification
-     */
-    T responseWithExceptionNotification(Throwable throwable, AdditionalNotificationData additionalNotificationData, Object... exceptionMessageArgumentList);
-
-    /**
-     * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
-     *
-     * @param data                       data to include in response
-     * @param additionalNotificationData additional notification data to add to notification
-     * @param <D>                        type of data
-     * @return response with notification
-     */
-    <D> T responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData);
-
-    /**
-     * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
-     *
-     * @param data                       data to include in response
-     * @param actionName                 name of the action for which to resolve notification
-     * @param additionalNotificationData additional notification data to add to notification
-     * @param <D>                        type of data
-     * @return response with notification
-     */
-    <D> T responseWithNotification(D data, String actionName, AdditionalNotificationData additionalNotificationData);
-
-    NotificationResolverService notificationResolverService();
-
-    default T responseWithValidationFailureNotification(Errors errors, Class<?> validationFailedOwningType) {
-        return responseWithValidationFailureNotification(errors, validationFailedOwningType, AdditionalNotificationData.empty());
-    }
-
-    default T responseWithValidationFailureNotification(ConstraintViolationException exception) {
-        return responseWithValidationFailureNotification(exception, AdditionalNotificationData.empty());
-    }
-
-    default T responseWithExceptionNotification(Throwable throwable, Object... additionalMessageArgumentList) {
-        return responseWithExceptionNotification(throwable, AdditionalNotificationData.empty(), additionalMessageArgumentList);
-    }
-
-    default <D> T responseWithNotificationActionResolvedFromRequest(D data) {
+    @Override
+    default <D> NotificationDataResponse<D> responseWithNotificationActionResolvedFromRequest(D data) {
         return responseWithNotificationActionResolvedFromRequest(data, AdditionalNotificationData.empty());
     }
 
-    default <D> T responseWithNotification(D data, String actionName) {
+    @Override
+    default <D> NotificationDataResponse<D> responseWithNotification(D data, String actionName) {
         return responseWithNotification(data, actionName, AdditionalNotificationData.empty());
-    }
-
-    default T responseWithNotificationActionResolvedFromRequest() {
-        return responseWithNotificationActionResolvedFromRequest(null, AdditionalNotificationData.empty());
-    }
-
-    default T responseWithNotification(String actionName) {
-        return responseWithNotification(null, actionName, AdditionalNotificationData.empty());
     }
 }

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/NotificationResponseService.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/NotificationResponseService.java
@@ -6,18 +6,31 @@ import net.croz.nrich.notification.api.response.NotificationResponse;
 
 public interface NotificationResponseService extends BaseNotificationResponseService<NotificationResponse> {
 
-    @Override
+    /**
+     * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
+     *
+     * @param data                       data to include in response
+     * @param additionalNotificationData additional notification data to add to notification
+     * @param <D>                        type of data
+     * @return response with notification
+     */
     <D> NotificationDataResponse<D> responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData);
 
-    @Override
+    /**
+     * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
+     *
+     * @param data                       data to include in response
+     * @param actionName                 name of the action for which to resolve notification
+     * @param additionalNotificationData additional notification data to add to notification
+     * @param <D>                        type of data
+     * @return response with notification
+     */
     <D> NotificationDataResponse<D> responseWithNotification(D data, String actionName, AdditionalNotificationData additionalNotificationData);
 
-    @Override
     default <D> NotificationDataResponse<D> responseWithNotificationActionResolvedFromRequest(D data) {
         return responseWithNotificationActionResolvedFromRequest(data, AdditionalNotificationData.empty());
     }
 
-    @Override
     default <D> NotificationDataResponse<D> responseWithNotification(D data, String actionName) {
         return responseWithNotification(data, actionName, AdditionalNotificationData.empty());
     }

--- a/nrich-notification-spring-boot-starter/src/main/java/net/croz/nrich/notification/starter/configuration/NrichNotificationAutoConfiguration.java
+++ b/nrich-notification-spring-boot-starter/src/main/java/net/croz/nrich/notification/starter/configuration/NrichNotificationAutoConfiguration.java
@@ -3,6 +3,7 @@ package net.croz.nrich.notification.starter.configuration;
 import lombok.RequiredArgsConstructor;
 import net.croz.nrich.notification.api.service.NotificationMessageResolverService;
 import net.croz.nrich.notification.api.service.NotificationResolverService;
+import net.croz.nrich.notification.api.service.BaseNotificationResponseService;
 import net.croz.nrich.notification.api.service.NotificationResponseService;
 import net.croz.nrich.notification.service.ConstraintConversionService;
 import net.croz.nrich.notification.service.DefaultConstraintConversionService;
@@ -42,9 +43,9 @@ public class NrichNotificationAutoConfiguration {
     }
 
     @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
-    @ConditionalOnMissingBean(NotificationResponseService.class)
+    @ConditionalOnMissingBean(BaseNotificationResponseService.class)
     @Bean
-    public WebMvcNotificationResponseService notificationResponseService(NotificationResolverService notificationResolverService) {
+    public NotificationResponseService notificationResponseService(NotificationResolverService notificationResolverService) {
         return new WebMvcNotificationResponseService(notificationResolverService);
     }
 

--- a/nrich-notification-spring-boot-starter/src/test/java/net/croz/nrich/notification/starter/NrichNotificationAutoConfigurationTest.java
+++ b/nrich-notification-spring-boot-starter/src/test/java/net/croz/nrich/notification/starter/NrichNotificationAutoConfigurationTest.java
@@ -1,7 +1,7 @@
 package net.croz.nrich.notification.starter;
 
 import net.croz.nrich.notification.api.service.NotificationResolverService;
-import net.croz.nrich.notification.api.service.NotificationResponseService;
+import net.croz.nrich.notification.api.service.BaseNotificationResponseService;
 import net.croz.nrich.notification.service.ConstraintConversionService;
 import net.croz.nrich.notification.starter.configuration.NrichNotificationAutoConfiguration;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ class NrichNotificationAutoConfigurationTest {
         contextRunner.run(context -> {
             assertThat(context).hasSingleBean(ConstraintConversionService.class);
             assertThat(context).hasSingleBean(NotificationResolverService.class);
-            assertThat(context).doesNotHaveBean(NotificationResponseService.class);
+            assertThat(context).doesNotHaveBean(BaseNotificationResponseService.class);
             assertThat(context).hasSingleBean(NrichNotificationAutoConfiguration.NotificationMessageSourceRegistrar.class);
         });
     }
@@ -44,7 +44,7 @@ class NrichNotificationAutoConfigurationTest {
     void shouldIncludeNotificationResponseServiceWhenRunningInWebEnvironment() {
         // expect
         webContextRunner.run(context ->
-            assertThat(context).hasSingleBean(NotificationResponseService.class)
+            assertThat(context).hasSingleBean(BaseNotificationResponseService.class)
         );
     }
 

--- a/nrich-notification/README.md
+++ b/nrich-notification/README.md
@@ -30,7 +30,7 @@ To be able to use this library following configuration is required:
     }
 
     @Bean
-    public NotificationResponseService<?> notificationResponseService(NotificationResolverService notificationResolverService) {
+    public NotificationResponseService notificationResponseService(NotificationResolverService notificationResolverService) {
         return new WebMvcNotificationResponseService(notificationResolverService);
     }
 
@@ -62,7 +62,7 @@ advice would look something like this:
 @RequiredArgsConstructor
 public class NotificationErrorHandlingRestControllerAdvice {
 
-    private NotificationResponseService<?> notificationResponseService;
+    private NotificationResponseService notificationResponseService;
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(Exception exception, HttpServletRequest request) {
@@ -93,7 +93,7 @@ Users can also use `NotificationResponseService` to return notifications with re
 @RequiredArgsConstructor
 public class NotificationTestController {
 
-    private NotificationResponseService<ResponseWithNotification<?>> notificationResponseService;
+    private NotificationResponseService notificationResponseService;
 
     private ExampleService exampleService;
 

--- a/nrich-notification/src/main/java/net/croz/nrich/notification/service/WebMvcNotificationResponseService.java
+++ b/nrich-notification/src/main/java/net/croz/nrich/notification/service/WebMvcNotificationResponseService.java
@@ -3,7 +3,8 @@ package net.croz.nrich.notification.service;
 import lombok.RequiredArgsConstructor;
 import net.croz.nrich.notification.api.model.AdditionalNotificationData;
 import net.croz.nrich.notification.api.model.Notification;
-import net.croz.nrich.notification.api.response.ResponseWithNotification;
+import net.croz.nrich.notification.api.response.NotificationDataResponse;
+import net.croz.nrich.notification.api.response.NotificationResponse;
 import net.croz.nrich.notification.api.service.NotificationResolverService;
 import net.croz.nrich.notification.api.service.NotificationResponseService;
 import net.croz.nrich.notification.constant.NotificationConstants;
@@ -17,43 +18,43 @@ import javax.validation.ConstraintViolationException;
 import java.util.Objects;
 
 @RequiredArgsConstructor
-public class WebMvcNotificationResponseService implements NotificationResponseService<ResponseWithNotification<?>> {
+public class WebMvcNotificationResponseService implements NotificationResponseService {
 
     private final NotificationResolverService notificationResolverService;
 
     @Override
-    public ResponseWithNotification<?> responseWithValidationFailureNotification(Errors errors, Class<?> validationFailedOwningType, AdditionalNotificationData additionalNotificationData) {
+    public NotificationResponse responseWithValidationFailureNotification(Errors errors, Class<?> validationFailedOwningType, AdditionalNotificationData additionalNotificationData) {
         Notification notification = notificationResolverService.createNotificationForValidationFailure(errors, validationFailedOwningType, additionalNotificationData);
 
-        return new ResponseWithNotification<>(null, notification);
+        return new NotificationResponse(notification);
     }
 
     @Override
-    public ResponseWithNotification<?> responseWithValidationFailureNotification(ConstraintViolationException exception, AdditionalNotificationData additionalNotificationData) {
+    public NotificationResponse responseWithValidationFailureNotification(ConstraintViolationException exception, AdditionalNotificationData additionalNotificationData) {
         Notification notification = notificationResolverService.createNotificationForValidationFailure(exception, additionalNotificationData);
 
-        return new ResponseWithNotification<>(null, notification);
+        return new NotificationResponse(notification);
     }
 
     @Override
-    public ResponseWithNotification<?> responseWithExceptionNotification(Throwable throwable, AdditionalNotificationData additionalNotificationData, Object... exceptionMessageArgumentList) {
+    public NotificationResponse responseWithExceptionNotification(Throwable throwable, AdditionalNotificationData additionalNotificationData, Object... exceptionMessageArgumentList) {
         Notification notification = notificationResolverService.createNotificationForException(throwable, additionalNotificationData, exceptionMessageArgumentList);
 
-        return new ResponseWithNotification<>(null, notification);
+        return new NotificationResponse(notification);
     }
 
     @Override
-    public <D> ResponseWithNotification<D> responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData) {
+    public <D> NotificationDataResponse<D> responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData) {
         String actionName = extractActionNameFromCurrentRequest();
 
         return responseWithNotification(data, actionName, additionalNotificationData);
     }
 
     @Override
-    public <D> ResponseWithNotification<D> responseWithNotification(D data, String actionName, AdditionalNotificationData additionalNotificationData) {
+    public <D> NotificationDataResponse<D> responseWithNotification(D data, String actionName, AdditionalNotificationData additionalNotificationData) {
         Notification notification = notificationResolverService.createNotificationForAction(actionName, additionalNotificationData);
 
-        return new ResponseWithNotification<>(data, notification);
+        return new NotificationDataResponse<>(notification, data);
     }
 
     @Override

--- a/nrich-notification/src/main/java/net/croz/nrich/notification/service/WebMvcNotificationResponseService.java
+++ b/nrich-notification/src/main/java/net/croz/nrich/notification/service/WebMvcNotificationResponseService.java
@@ -44,6 +44,20 @@ public class WebMvcNotificationResponseService implements NotificationResponseSe
     }
 
     @Override
+    public NotificationResponse responseWithNotificationActionResolvedFromRequest(AdditionalNotificationData additionalNotificationData) {
+        String actionName = extractActionNameFromCurrentRequest();
+
+        return responseWithNotification(actionName, additionalNotificationData);
+    }
+
+    @Override
+    public NotificationResponse responseWithNotification(String actionName, AdditionalNotificationData additionalNotificationData) {
+        Notification notification = notificationResolverService.createNotificationForAction(actionName, additionalNotificationData);
+
+        return new NotificationResponse(notification);
+    }
+
+    @Override
     public <D> NotificationDataResponse<D> responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData) {
         String actionName = extractActionNameFromCurrentRequest();
 

--- a/nrich-notification/src/test/java/net/croz/nrich/notification/service/WebMvcNotificationResponseServiceTest.java
+++ b/nrich-notification/src/test/java/net/croz/nrich/notification/service/WebMvcNotificationResponseServiceTest.java
@@ -4,7 +4,8 @@ import net.croz.nrich.notification.api.model.AdditionalNotificationData;
 import net.croz.nrich.notification.api.model.Notification;
 import net.croz.nrich.notification.api.model.NotificationSeverity;
 import net.croz.nrich.notification.api.model.ValidationFailureNotification;
-import net.croz.nrich.notification.api.response.ResponseWithNotification;
+import net.croz.nrich.notification.api.response.NotificationDataResponse;
+import net.croz.nrich.notification.api.response.NotificationResponse;
 import net.croz.nrich.notification.api.service.NotificationResolverService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,37 +59,37 @@ class WebMvcNotificationResponseServiceTest {
     @Test
     void shouldCreateResponseForValidationFailure() {
         // when
-        ResponseWithNotification<?> responseWithNotification = notificationResponseService.responseWithValidationFailureNotification(mock(Errors.class), Object.class);
+        NotificationResponse notificationResponse = notificationResponseService.responseWithValidationFailureNotification(mock(Errors.class), Object.class);
 
         // then
-        assertThat(responseWithNotification).isNotNull();
-        assertThat(responseWithNotification.getNotification()).isNotNull();
-        assertThat(responseWithNotification.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
-        assertThat(responseWithNotification.getNotification().getContent()).isEqualTo("Validation failed 1");
+        assertThat(notificationResponse).isNotNull();
+        assertThat(notificationResponse.getNotification()).isNotNull();
+        assertThat(notificationResponse.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
+        assertThat(notificationResponse.getNotification().getContent()).isEqualTo("Validation failed 1");
     }
 
     @Test
     void shouldCreateResponseForValidationFailureForConstraintViolation() {
         // when
-        ResponseWithNotification<?> responseWithNotification = notificationResponseService.responseWithValidationFailureNotification(mock(ConstraintViolationException.class));
+        NotificationResponse notificationResponse = notificationResponseService.responseWithValidationFailureNotification(mock(ConstraintViolationException.class));
 
         // then
-        assertThat(responseWithNotification).isNotNull();
-        assertThat(responseWithNotification.getNotification()).isNotNull();
-        assertThat(responseWithNotification.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
-        assertThat(responseWithNotification.getNotification().getContent()).isEqualTo("Validation failed 2");
+        assertThat(notificationResponse).isNotNull();
+        assertThat(notificationResponse.getNotification()).isNotNull();
+        assertThat(notificationResponse.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
+        assertThat(notificationResponse.getNotification().getContent()).isEqualTo("Validation failed 2");
     }
 
     @Test
     void shouldCreateResponseForException() {
         // when
-        ResponseWithNotification<?> responseWithNotification = notificationResponseService.responseWithExceptionNotification(new Exception());
+        NotificationResponse notificationResponse = notificationResponseService.responseWithExceptionNotification(new Exception());
 
         // then
-        assertThat(responseWithNotification).isNotNull();
-        assertThat(responseWithNotification.getNotification()).isNotNull();
-        assertThat(responseWithNotification.getNotification().getSeverity()).isEqualTo(NotificationSeverity.ERROR);
-        assertThat(responseWithNotification.getNotification().getContent()).isEqualTo("Exception");
+        assertThat(notificationResponse).isNotNull();
+        assertThat(notificationResponse.getNotification()).isNotNull();
+        assertThat(notificationResponse.getNotification().getSeverity()).isEqualTo(NotificationSeverity.ERROR);
+        assertThat(notificationResponse.getNotification().getContent()).isEqualTo("Exception");
     }
 
     @Test
@@ -99,14 +100,14 @@ class WebMvcNotificationResponseServiceTest {
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockHttpServletRequest));
 
         // when
-        ResponseWithNotification<?> responseWithNotification = notificationResponseService.responseWithNotificationActionResolvedFromRequest(data);
+        NotificationDataResponse<String> notificationDataResponse = notificationResponseService.responseWithNotificationActionResolvedFromRequest(data);
 
         // then
-        assertThat(responseWithNotification).isNotNull();
-        assertThat(responseWithNotification.getData()).isEqualTo(data);
-        assertThat(responseWithNotification.getNotification()).isNotNull();
-        assertThat(responseWithNotification.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
-        assertThat(responseWithNotification.getNotification().getContent()).isEqualTo("Action success");
+        assertThat(notificationDataResponse).isNotNull();
+        assertThat(notificationDataResponse.getData()).isEqualTo(data);
+        assertThat(notificationDataResponse.getNotification()).isNotNull();
+        assertThat(notificationDataResponse.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
+        assertThat(notificationDataResponse.getNotification().getContent()).isEqualTo("Action success");
     }
 
     @Test
@@ -115,14 +116,14 @@ class WebMvcNotificationResponseServiceTest {
         String data = "data";
 
         // when
-        ResponseWithNotification<?> responseWithNotification = notificationResponseService.responseWithNotification(data, "actionPrefix.actionSuffix");
+        NotificationDataResponse<String> notificationDataResponse = notificationResponseService.responseWithNotification(data, "actionPrefix.actionSuffix");
 
         // then
-        assertThat(responseWithNotification).isNotNull();
-        assertThat(responseWithNotification.getData()).isEqualTo(data);
-        assertThat(responseWithNotification.getNotification()).isNotNull();
-        assertThat(responseWithNotification.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
-        assertThat(responseWithNotification.getNotification().getContent()).isEqualTo("Action success");
+        assertThat(notificationDataResponse).isNotNull();
+        assertThat(notificationDataResponse.getData()).isEqualTo(data);
+        assertThat(notificationDataResponse.getNotification()).isNotNull();
+        assertThat(notificationDataResponse.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
+        assertThat(notificationDataResponse.getNotification().getContent()).isEqualTo("Action success");
     }
 
     @Test
@@ -132,24 +133,24 @@ class WebMvcNotificationResponseServiceTest {
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockHttpServletRequest));
 
         // when
-        ResponseWithNotification<?> responseWithNotification = notificationResponseService.responseWithNotificationActionResolvedFromRequest();
+        NotificationResponse notificationDataResponse = notificationResponseService.responseWithNotificationActionResolvedFromRequest();
 
         // then
-        assertThat(responseWithNotification).isNotNull();
-        assertThat(responseWithNotification.getNotification()).isNotNull();
-        assertThat(responseWithNotification.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
-        assertThat(responseWithNotification.getNotification().getContent()).isEqualTo("Action success");
+        assertThat(notificationDataResponse).isNotNull();
+        assertThat(notificationDataResponse.getNotification()).isNotNull();
+        assertThat(notificationDataResponse.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
+        assertThat(notificationDataResponse.getNotification().getContent()).isEqualTo("Action success");
     }
 
     @Test
     void shouldCreateNotificationFromActionNameWithoutData() {
         // when
-        ResponseWithNotification<?> responseWithNotification = notificationResponseService.responseWithNotification("actionPrefix.actionSuffix");
+        NotificationResponse notificationDataResponse = notificationResponseService.responseWithNotification("actionPrefix.actionSuffix");
 
         // then
-        assertThat(responseWithNotification).isNotNull();
-        assertThat(responseWithNotification.getNotification()).isNotNull();
-        assertThat(responseWithNotification.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
-        assertThat(responseWithNotification.getNotification().getContent()).isEqualTo("Action success");
+        assertThat(notificationDataResponse).isNotNull();
+        assertThat(notificationDataResponse.getNotification()).isNotNull();
+        assertThat(notificationDataResponse.getNotification().getSeverity()).isEqualTo(NotificationSeverity.INFO);
+        assertThat(notificationDataResponse.getNotification().getContent()).isEqualTo("Action success");
     }
 }

--- a/nrich-webmvc-spring-boot-starter/src/main/java/net/croz/nrich/webmvc/starter/configuration/NrichWebMvcAutoConfiguration.java
+++ b/nrich-webmvc-spring-boot-starter/src/main/java/net/croz/nrich/webmvc/starter/configuration/NrichWebMvcAutoConfiguration.java
@@ -1,7 +1,7 @@
 package net.croz.nrich.webmvc.starter.configuration;
 
 import net.croz.nrich.logging.api.service.LoggingService;
-import net.croz.nrich.notification.api.service.NotificationResponseService;
+import net.croz.nrich.notification.api.service.BaseNotificationResponseService;
 import net.croz.nrich.springboot.condition.ConditionalOnPropertyNotEmpty;
 import net.croz.nrich.webmvc.advice.ControllerEditorRegistrationAdvice;
 import net.croz.nrich.webmvc.advice.NotificationErrorHandlingRestControllerAdvice;
@@ -22,7 +22,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@ConditionalOnBean({ NotificationResponseService.class, LoggingService.class })
+@ConditionalOnBean({ BaseNotificationResponseService.class, LoggingService.class })
 @EnableConfigurationProperties(NrichWebMvcProperties.class)
 @Configuration(proxyBeanMethods = false)
 public class NrichWebMvcAutoConfiguration {
@@ -54,7 +54,7 @@ public class NrichWebMvcAutoConfiguration {
 
     @ConditionalOnProperty(name = "nrich.webmvc.controller-advice-enabled", havingValue = "true", matchIfMissing = true)
     @Bean
-    public NotificationErrorHandlingRestControllerAdvice notificationRestControllerAdvice(NrichWebMvcProperties webMvcProperties, NotificationResponseService<?> notificationResponseService,
+    public NotificationErrorHandlingRestControllerAdvice notificationRestControllerAdvice(NrichWebMvcProperties webMvcProperties, BaseNotificationResponseService<?> notificationResponseService,
                                                                                           LoggingService loggingService, ExceptionHttpStatusResolverService exceptionHttpStatusResolverService,
                                                                                           @Autowired(required = false) ExceptionAuxiliaryDataResolverService exceptionAuxiliaryDataResolverService) {
         return new NotificationErrorHandlingRestControllerAdvice(

--- a/nrich-webmvc-spring-boot-starter/src/test/java/net/croz/nrich/webmvc/starter/configuration/stub/NotificationResponseTestService.java
+++ b/nrich-webmvc-spring-boot-starter/src/test/java/net/croz/nrich/webmvc/starter/configuration/stub/NotificationResponseTestService.java
@@ -25,12 +25,12 @@ public class NotificationResponseTestService implements BaseNotificationResponse
     }
 
     @Override
-    public <D> Object responseWithNotificationActionResolvedFromRequest(D data, AdditionalNotificationData additionalNotificationData) {
+    public Object responseWithNotification(String actionName, AdditionalNotificationData additionalNotificationData) {
         return null;
     }
 
     @Override
-    public <D> Object responseWithNotification(D data, String actionName, AdditionalNotificationData additionalNotificationData) {
+    public Object responseWithNotificationActionResolvedFromRequest(AdditionalNotificationData additionalNotificationData) {
         return null;
     }
 

--- a/nrich-webmvc-spring-boot-starter/src/test/java/net/croz/nrich/webmvc/starter/configuration/stub/NotificationResponseTestService.java
+++ b/nrich-webmvc-spring-boot-starter/src/test/java/net/croz/nrich/webmvc/starter/configuration/stub/NotificationResponseTestService.java
@@ -2,12 +2,12 @@ package net.croz.nrich.webmvc.starter.configuration.stub;
 
 import net.croz.nrich.notification.api.model.AdditionalNotificationData;
 import net.croz.nrich.notification.api.service.NotificationResolverService;
-import net.croz.nrich.notification.api.service.NotificationResponseService;
+import net.croz.nrich.notification.api.service.BaseNotificationResponseService;
 import org.springframework.validation.Errors;
 
 import javax.validation.ConstraintViolationException;
 
-public class NotificationResponseTestService implements NotificationResponseService<Object> {
+public class NotificationResponseTestService implements BaseNotificationResponseService<Object> {
 
     @Override
     public Object responseWithValidationFailureNotification(Errors errors, Class<?> validationFailedOwningType, AdditionalNotificationData additionalNotificationData) {

--- a/nrich-webmvc/README.md
+++ b/nrich-webmvc/README.md
@@ -37,7 +37,7 @@ nrich-webmvc depends on nrich-logging and nrich-notification libraries but users
     }
 
     @Bean
-    public NotificationErrorHandlingRestControllerAdvice notificationErrorHandlingRestControllerAdvice(NotificationResponseService<?> notificationResponseService, LoggingService loggingService, ExceptionAuxiliaryDataResolverService exceptionAuxiliaryDataResolverService, ExceptionHttpStatusResolverService exceptionHttpStatusResolverService) {
+    public NotificationErrorHandlingRestControllerAdvice notificationErrorHandlingRestControllerAdvice(BaseNotificationResponseService<?> notificationResponseService, LoggingService loggingService, ExceptionAuxiliaryDataResolverService exceptionAuxiliaryDataResolverService, ExceptionHttpStatusResolverService exceptionHttpStatusResolverService) {
         return new NotificationErrorHandlingRestControllerAdvice(Collections.singletonList(ExecutionException.class.getName()), Collections.singletonList("uuid"), notificationResponseService, loggingService, exceptionAuxiliaryDataResolverService, exceptionHttpStatusResolverService);
     }
 

--- a/nrich-webmvc/src/main/java/net/croz/nrich/webmvc/advice/NotificationErrorHandlingRestControllerAdvice.java
+++ b/nrich-webmvc/src/main/java/net/croz/nrich/webmvc/advice/NotificationErrorHandlingRestControllerAdvice.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import net.croz.nrich.core.api.exception.ExceptionWithArguments;
 import net.croz.nrich.logging.api.service.LoggingService;
 import net.croz.nrich.notification.api.model.AdditionalNotificationData;
-import net.croz.nrich.notification.api.service.NotificationResponseService;
+import net.croz.nrich.notification.api.service.BaseNotificationResponseService;
 import net.croz.nrich.webmvc.api.service.ExceptionAuxiliaryDataResolverService;
 import net.croz.nrich.webmvc.api.service.ExceptionHttpStatusResolverService;
 import org.springframework.http.HttpStatus;
@@ -30,7 +30,7 @@ public class NotificationErrorHandlingRestControllerAdvice {
 
     private final List<String> exceptionAuxiliaryDataToIncludeInNotification;
 
-    private final NotificationResponseService<?> notificationResponseService;
+    private final BaseNotificationResponseService<?> notificationResponseService;
 
     private final LoggingService loggingService;
 

--- a/nrich-webmvc/src/test/java/net/croz/nrich/webmvc/WebmvcTestConfiguration.java
+++ b/nrich-webmvc/src/test/java/net/croz/nrich/webmvc/WebmvcTestConfiguration.java
@@ -3,6 +3,7 @@ package net.croz.nrich.webmvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.croz.nrich.logging.api.service.LoggingService;
 import net.croz.nrich.logging.service.Slf4jLoggingService;
+import net.croz.nrich.notification.api.service.BaseNotificationResponseService;
 import net.croz.nrich.notification.api.service.NotificationMessageResolverService;
 import net.croz.nrich.notification.api.service.NotificationResolverService;
 import net.croz.nrich.notification.api.service.NotificationResponseService;
@@ -81,7 +82,7 @@ public class WebmvcTestConfiguration {
     }
 
     @Bean
-    public NotificationResponseService<?> notificationResponseService(NotificationResolverService notificationResolverService) {
+    public NotificationResponseService notificationResponseService(NotificationResolverService notificationResolverService) {
         return new WebMvcNotificationResponseService(notificationResolverService);
     }
 
@@ -111,7 +112,7 @@ public class WebmvcTestConfiguration {
     }
 
     @Bean
-    public NotificationErrorHandlingRestControllerAdvice notificationErrorHandlingRestControllerAdvice(NotificationResponseService<?> notificationResponseService, LoggingService loggingService,
+    public NotificationErrorHandlingRestControllerAdvice notificationErrorHandlingRestControllerAdvice(BaseNotificationResponseService<?> notificationResponseService, LoggingService loggingService,
                                                                                                        ExceptionAuxiliaryDataResolverService exceptionAuxiliaryDataResolverService,
                                                                                                        ExceptionHttpStatusResolverService exceptionHttpStatusResolverService) {
         return new NotificationErrorHandlingRestControllerAdvice(


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.2.1
* Module:
nrich-notification, nrich-webmvc, nrich-logging
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Added a separate class to represent a response notification without data, renamed existing class to end with Response suffix, renamed existing and added an additional interface in NotificationResolverService hierarchy that makes the usage easier.

### Details

Added a separate class to represent a response notification without data, renamed existing class to end with Response suffix, renamed existing and added an additional interface in NotificationResolverService hierarchy that makes the usage easier.

### Related issue

https://github.com/croz-ltd/nrich/issues/68
## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Breaking change (fix, enhancement or feature that would cause existing functionality to change in backward-incompatible way)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
-  ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
