### PR TITLE
Fix parsing of dates

### DIFF
--- a/nrich-search/src/test/java/net/croz/nrich/search/SearchTestConfiguration.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/SearchTestConfiguration.java
@@ -63,7 +63,7 @@ public class SearchTestConfiguration {
 
     @Bean
     public StringToTypeConverter<Object> defaultStringToTypeConverter() {
-        List<String> dateFormatList = Arrays.asList("dd.MM.yyyy", "yyyy-MM-dd'T'HH:mm");
+        List<String> dateFormatList = Arrays.asList("dd-MM-yyyy", "dd-MM-yyyy'T'HH:mm");
         List<String> decimalFormatList = Arrays.asList("#0.00", "#0,00");
         String booleanTrueRegexPattern = "^(?i)\\s*(true|yes)\\s*$";
         String booleanFalseRegexPattern = "^(?i)\\s*(false|no)\\s*$";

--- a/nrich-search/src/test/java/net/croz/nrich/search/converter/DefaultStringToEntityPropertyMapConverterTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/converter/DefaultStringToEntityPropertyMapConverterTest.java
@@ -27,7 +27,7 @@ class DefaultStringToEntityPropertyMapConverterTest {
     @Test
     void shouldConvertStringToEntityPropertyMap() {
         // given
-        String value = "01.01.1970";
+        String value = "01-01-1970";
 
         // when
         Map<String, Object> result = stringToEntityPropertyMapConverter.convert(value, Arrays.asList("name", "date", "nestedEntity.nestedName"), managedTypeOfTestEntity());

--- a/nrich-search/src/test/java/net/croz/nrich/search/converter/DefaultStringToTypeConverterTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/converter/DefaultStringToTypeConverterTest.java
@@ -1,29 +1,39 @@
 package net.croz.nrich.search.converter;
 
-import net.croz.nrich.search.SearchTestConfiguration;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.TimeZone;
 import java.util.stream.Stream;
 
 import static net.croz.nrich.search.converter.testutil.ConverterGeneratingUtil.dateOf;
+import static net.croz.nrich.search.converter.testutil.ConverterGeneratingUtil.instantOf;
 import static net.croz.nrich.search.converter.testutil.ConverterGeneratingUtil.localDateOf;
 import static net.croz.nrich.search.converter.testutil.ConverterGeneratingUtil.localDateTimeOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@SpringJUnitConfig(SearchTestConfiguration.class)
 class DefaultStringToTypeConverterTest {
 
-    @Autowired
-    private DefaultStringToTypeConverter defaultStringToTypeConverter;
+    private final DefaultStringToTypeConverter defaultStringToTypeConverter = new DefaultStringToTypeConverter(
+        Arrays.asList("dd-MM-yyyy", "dd-MM-yyyy'T'HH:mm", "dd-MM-yyyy'T'HH:mm'Z'", "dd-MM-yyyy'T'HH:mmXXX", "HH:mmXXX"),
+        Arrays.asList("#0.00", "#0,00"), "^(?i)\\s*(true|yes)\\s*$", "^(?i)\\s*(false|no)\\s*$"
+    );
+
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
 
     @MethodSource("shouldConvertStringValueToRequiredValueMethodSource")
     @ParameterizedTest
@@ -36,6 +46,8 @@ class DefaultStringToTypeConverterTest {
     }
 
     private static Stream<Arguments> shouldConvertStringValueToRequiredValueMethodSource() {
+        ZoneId defaultZone = ZoneId.systemDefault();
+
         return Stream.of(
             arguments(null, Boolean.class, null),
             arguments(null, DefaultStringToTypeConverterTest.class, null),
@@ -47,10 +59,14 @@ class DefaultStringToTypeConverterTest {
             arguments("5", Integer.class, 5),
             arguments("5", Short.class, Short.valueOf("5")),
             arguments("ONE", Value.class, Value.ONE),
-            arguments("01.01.1970", Date.class, dateOf("01.01.1970")),
+            arguments("01-01-1970", Date.class, dateOf("01-01-1970")),
             arguments("not a date", Date.class, null),
-            arguments("01.01.1970", LocalDate.class, localDateOf("01.01.1970")),
-            arguments("2020-01-01T11:11", LocalDateTime.class, localDateTimeOf("2020-01-01T11:11")),
+            arguments("01-01-2020T11:11", Instant.class, instantOf("01-01-2020T11:11")),
+            arguments("01-01-1970", LocalDate.class, localDateOf("01-01-1970")),
+            arguments("01-01-2020T11:11", LocalDateTime.class, localDateTimeOf("01-01-2020T11:11")),
+            arguments("01-01-2020T11:11Z", OffsetDateTime.class, instantOf("01-01-2020T11:11").atZone(defaultZone).toOffsetDateTime()),
+            arguments("11:11Z", OffsetTime.class, instantOf("01-01-2020T11:11").atZone(defaultZone).toOffsetDateTime().toOffsetTime()),
+            arguments("01-01-2020T11:11Z", ZonedDateTime.class, instantOf("01-01-2020T11:11").atZone(defaultZone)),
             arguments("1.1", BigDecimal.class, new BigDecimal("1.1")),
             arguments("1.1", Float.class, Double.valueOf("1.1")),
             arguments("1.1", Double.class, Double.valueOf("1.1")),

--- a/nrich-search/src/test/java/net/croz/nrich/search/converter/testutil/ConverterGeneratingUtil.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/converter/testutil/ConverterGeneratingUtil.java
@@ -3,26 +3,36 @@ package net.croz.nrich.search.converter.testutil;
 import lombok.SneakyThrows;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 public final class ConverterGeneratingUtil {
+
+    private static final String DATE_PATTERN = "dd-MM-yyyy";
+
+    private static final String DATE_TIME_PATTERN = "dd-MM-yyyy'T'HH:mm";
 
     private ConverterGeneratingUtil() {
     }
 
     @SneakyThrows
     public static Date dateOf(String value) {
-        return new SimpleDateFormat("dd.MM.yyyy").parse(value);
+        return new SimpleDateFormat(DATE_PATTERN).parse(value);
     }
 
     public static LocalDate localDateOf(String value) {
-        return DateTimeFormatter.ofPattern("dd.MM.yyyy").parse(value, LocalDate::from);
+        return DateTimeFormatter.ofPattern(DATE_PATTERN).parse(value, LocalDate::from);
     }
 
     public static LocalDateTime localDateTimeOf(String value) {
-        return DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm").parse(value, LocalDateTime::from);
+        return DateTimeFormatter.ofPattern(DATE_TIME_PATTERN).parse(value, LocalDateTime::from);
+    }
+
+    public static Instant instantOf(String value) {
+        return DateTimeFormatter.ofPattern(DATE_TIME_PATTERN).withZone(ZoneId.systemDefault()).parse(value, Instant::from);
     }
 }

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaStringSearchExecutorTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaStringSearchExecutorTest.java
@@ -42,7 +42,7 @@ class JpaStringSearchExecutorTest {
         generateListForStringSearch(entityManager);
 
         // when
-        Optional<TestStringSearchEntity> result = testEntityStringSearchRepository.findOne("01.01.1970", Collections.singletonList("localDate"), EMPTY_CONFIGURATION);
+        Optional<TestStringSearchEntity> result = testEntityStringSearchRepository.findOne("01-01-1970", Collections.singletonList("localDate"), EMPTY_CONFIGURATION);
 
         // then
         assertThat(result).isNotEmpty();
@@ -54,7 +54,7 @@ class JpaStringSearchExecutorTest {
         generateListForStringSearch(entityManager);
 
         // when
-        Optional<TestStringSearchEntity> result = testEntityStringSearchRepository.findOne("01.01.2000", Collections.singletonList("localDate"), EMPTY_CONFIGURATION);
+        Optional<TestStringSearchEntity> result = testEntityStringSearchRepository.findOne("01-01-2000", Collections.singletonList("localDate"), EMPTY_CONFIGURATION);
 
         // then
         assertThat(result).isEmpty();
@@ -68,7 +68,7 @@ class JpaStringSearchExecutorTest {
         SearchConfiguration<TestStringSearchEntity, TestStringSearchEntity, Map<String, Object>> searchConfiguration = SearchConfiguration.emptyConfigurationMatchingAny();
 
         // when
-        Optional<TestStringSearchEntity> result = testEntityStringSearchRepository.findOne("01.01.1970", Arrays.asList("age", "localDate", "name"), searchConfiguration);
+        Optional<TestStringSearchEntity> result = testEntityStringSearchRepository.findOne("01-01-1970", Arrays.asList("age", "localDate", "name"), searchConfiguration);
 
         // then
         assertThat(result).isNotEmpty();


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.2.1
* Module:
nrich-search

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Parsing of Instant, OffsetDateTime, OffsetTime and ZonedDateTime was failing since zone was absent in DateFormatter, added system zone to DateFormatter and synced date and date time formats in tests.

### Details

Parsing of Instant, OffsetDateTime, OffsetTime and ZonedDateTime was failing since zone was absent in DateFormatter, added system zone to DateFormatter and synced date and date time formats in tests.

### Related issue

https://github.com/croz-ltd/nrich/issues/76

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
