### PR TITLE
Feature change resolving of form and column display values

### DIFF
--- a/nrich-registry/build.gradle
+++ b/nrich-registry/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   enversImplementation "org.hibernate:hibernate-envers"
 
   implementation project(":nrich-search")
+  implementation "org.apache.commons:commons-lang3"
   implementation "com.fasterxml.jackson.core:jackson-databind"
   implementation "org.springframework.data:spring-data-jpa"
   implementation "org.modelmapper:modelmapper"

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/core/constants/RegistryCoreConstants.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/core/constants/RegistryCoreConstants.java
@@ -1,0 +1,13 @@
+package net.croz.nrich.registry.core.constants;
+
+public final class RegistryCoreConstants {
+
+    public static final String BLANK = "";
+
+    public static final String DOT = ".";
+
+    public static final String SPACE = " ";
+
+    private RegistryCoreConstants() {
+    }
+}

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/core/constants/RegistryQueryConstants.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/core/constants/RegistryQueryConstants.java
@@ -16,8 +16,6 @@ public final class RegistryQueryConstants {
 
     public static final String FIND_QUERY_JOIN_FETCH = " left join fetch " + ENTITY_ALIAS + ".%s ";
 
-    public static final String QUERY_JOIN_SEPARATOR = " ";
-
     private RegistryQueryConstants() {
     }
 }

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/core/service/DefaultRegistryConfigurationResolverService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/core/service/DefaultRegistryConfigurationResolverService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import net.croz.nrich.registry.api.core.model.RegistryConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryOverrideConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryOverrideConfigurationHolder;
+import net.croz.nrich.registry.core.constants.RegistryCoreConstants;
 import net.croz.nrich.registry.core.constants.RegistryEnversConstants;
 import net.croz.nrich.registry.core.model.PropertyWithType;
 import net.croz.nrich.registry.core.model.RegistryDataConfiguration;
@@ -172,8 +173,8 @@ public class DefaultRegistryConfigurationResolverService implements RegistryConf
         SearchConfiguration<Object, Object, Map<String, Object>> searchConfiguration = SearchConfiguration.emptyConfigurationMatchingAny();
 
         List<SearchJoin<Map<String, Object>>> searchJoinList = Stream.concat(
-                createSearchJoinStreamFromAssociationList(managedTypeWrapper.getSingularAssociationList(), ""),
-                createSearchJoinStreamFromAssociationList(managedTypeWrapper.getSingularEmbeddedTypeAssociationList(), managedTypeWrapper.getIdAttributeName() + "."))
+                createSearchJoinStreamFromAssociationList(managedTypeWrapper.getSingularAssociationList(), RegistryCoreConstants.BLANK),
+                createSearchJoinStreamFromAssociationList(managedTypeWrapper.getSingularEmbeddedTypeAssociationList(), managedTypeWrapper.getIdAttributeName() + RegistryCoreConstants.DOT))
             .collect(Collectors.toList());
 
         searchConfiguration.setJoinList(searchJoinList);

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/core/service/EntityManagerRegistryEntityFinderService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/core/service/EntityManagerRegistryEntityFinderService.java
@@ -3,6 +3,7 @@ package net.croz.nrich.registry.core.service;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.croz.nrich.registry.api.core.service.RegistryEntityFinderService;
+import net.croz.nrich.registry.core.constants.RegistryCoreConstants;
 import net.croz.nrich.registry.core.constants.RegistryQueryConstants;
 import net.croz.nrich.registry.core.support.ManagedTypeWrapper;
 import org.modelmapper.ModelMapper;
@@ -33,7 +34,7 @@ public class EntityManagerRegistryEntityFinderService implements RegistryEntityF
 
         String joinFetchQueryPart = classNameManagedTypeWrapperMap.get(type.getName()).getSingularAssociationList().stream()
             .map(attribute -> String.format(RegistryQueryConstants.FIND_QUERY_JOIN_FETCH, attribute.getName()))
-            .collect(Collectors.joining(RegistryQueryConstants.QUERY_JOIN_SEPARATOR));
+            .collect(Collectors.joining(RegistryCoreConstants.SPACE));
 
         String entityWithAlias = String.format(RegistryQueryConstants.PROPERTY_SPACE_FORMAT, type.getName(), RegistryQueryConstants.ENTITY_ALIAS);
         String querySelectPart = String.format(RegistryQueryConstants.PROPERTY_SPACE_FORMAT, entityWithAlias, joinFetchQueryPart.trim());

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationServiceTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationServiceTest.java
@@ -62,6 +62,12 @@ class DefaultRegistryConfigurationServiceTest {
 
         assertThat(registryEntityConfiguration.getPropertyConfigurationList()).hasSize(5);
         assertThat(registryEntityConfiguration.getPropertyConfigurationList()).extracting("name").containsExactly("name", "id", "nonEditableProperty", "floatNumber", "doubleNumber");
+        assertThat(registryEntityConfiguration.getPropertyConfigurationList()).extracting("formLabel").containsExactly(
+            "Name of property", "Id", "Non editable property", "Float number", "Double number"
+        );
+        assertThat(registryEntityConfiguration.getPropertyConfigurationList()).extracting("columnHeader").containsExactly(
+            "Header of property", "Id", "Non editable property", "Float number", "Double number"
+        );
         assertThat(registryEntityConfiguration.getPropertyConfigurationList()).extracting("isDecimal").containsExactly(false, false, false, true, true);
 
         // and when


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.2.1
* Module:
nrich-registry
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Changed default display values for formLabel and columnHeader now they use capitalised and space separated attribute name i.e. (carId will be Car id) so the need for overriding of display values can be reduced.

### Details

Changed default display values for formLabel and columnHeader now they use capitalised and space separated attribute name i.e. (carId will be Car id) so the need for overriding of display values can be reduced.

### Related issue

https://github.com/croz-ltd/nrich/issues/72

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
