### PR TITLE
Feature add logging spring boot starter

### DIFF
--- a/nrich-logging-spring-boot-starter/README.MD
+++ b/nrich-logging-spring-boot-starter/README.MD
@@ -1,0 +1,63 @@
+# nrich-logging-spring-boot-starter
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.croz.nrich/nrich-logging-spring-boot-starter/badge.svg?color=blue)](https://maven-badges.herokuapp.com/maven-central/net.croz.nrich/nrich-logging-spring-boot-starter)
+
+## Overview
+
+Spring Boot starter for nrich-logging module. The purpose of nrich-logging is to provide a unified and configurable logging format. It is used by nrich-webmvc module to log exceptions, it also allows
+logging level and logging verbosity (details about exception) to be easily configured through `message.properties`.
+Starter module provides a `@Configuration` class with default configuration of nrich-logging module (while allowing for overriding with conditional annotations) and does automatic registration
+through `spring.factories`.
+
+## Usage
+
+### Adding the Dependency
+
+The artifact is published on [Maven Central Repository](https://search.maven.org/). To include the dependency use the following configurations.
+
+With Maven:
+
+```xml
+
+<dependency>
+    <groupId>net.croz.nrich</groupId>
+    <artifactId>nrich-logging-spring-boot-starter</artifactId>
+    <version>${nrich.version}</version>
+</dependency>
+
+```
+
+With Gradle:
+
+```groovy
+implementation "net.croz.nrich:nrich-logging-spring-boot-starter:${nrich.version}"
+```
+
+Note if using nrich-bom dependency versions should be omitted.
+
+### Using the library
+
+After adding the dependency a bean of type `LoggingService` is available for dependency injection. The purpose of the `LoggingService` it to be used by `NotificationErrorHandlingRestControllerAdvice`
+to log uncaught exception but users can also use it to manually log caught exceptions. An example usage is given bellow (more detailed examples are found in nrich-logging
+[README.MD](../nrich-logging/README.md)):
+
+```java
+
+@RequiredArgsConstructor
+@Service
+public class ExampleService {
+
+    private final LoggingService loggingService;
+
+    public void executeAction() {
+        try {
+            // some operation that can throw an exception
+        }
+        catch (Exception exception) {
+            loggingService.logInternalException(exception, null);
+        }
+    }
+}
+
+
+```

--- a/nrich-logging-spring-boot-starter/build.gradle
+++ b/nrich-logging-spring-boot-starter/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+  api project(":nrich-logging-api")
+
+  annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
+  implementation project(":nrich-logging")
+
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
+
+  testImplementation "org.springframework.boot:spring-boot-starter-test"
+}

--- a/nrich-logging-spring-boot-starter/src/main/java/net/croz/nrich/logging/starter/configuration/NrichLoggingAutoConfiguration.java
+++ b/nrich-logging-spring-boot-starter/src/main/java/net/croz/nrich/logging/starter/configuration/NrichLoggingAutoConfiguration.java
@@ -1,0 +1,20 @@
+package net.croz.nrich.logging.starter.configuration;
+
+import net.croz.nrich.logging.api.service.LoggingService;
+import net.croz.nrich.logging.service.Slf4jLoggingService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@ConditionalOnBean(MessageSource.class)
+@Configuration(proxyBeanMethods = false)
+public class NrichLoggingAutoConfiguration {
+
+    @ConditionalOnMissingBean
+    @Bean
+    public LoggingService loggingService(MessageSource messageSource) {
+        return new Slf4jLoggingService(messageSource);
+    }
+}

--- a/nrich-logging-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/nrich-logging-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=net.croz.nrich.logging.starter.configuration.NrichLoggingAutoConfiguration

--- a/nrich-logging-spring-boot-starter/src/test/java/net/croz/nrich/logging/starter/configuration/NrichLoggingAutoConfigurationTest.java
+++ b/nrich-logging-spring-boot-starter/src/test/java/net/croz/nrich/logging/starter/configuration/NrichLoggingAutoConfigurationTest.java
@@ -1,0 +1,30 @@
+package net.croz.nrich.logging.starter.configuration;
+
+import net.croz.nrich.logging.api.service.LoggingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.support.ResourceBundleMessageSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NrichLoggingAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(NrichLoggingAutoConfiguration.class));
+
+    @Test
+    void shouldConfigureDefaultConfiguration() {
+        // expect
+        contextRunner.withBean(ResourceBundleMessageSource.class).run(context ->
+            assertThat(context).hasSingleBean(LoggingService.class)
+        );
+    }
+
+    @Test
+    void shouldNotConfigureWhenMessageSourceIsMissing() {
+        // expect
+        contextRunner.run(context ->
+            assertThat(context).doesNotHaveBean(LoggingService.class)
+        );
+    }
+}

--- a/nrich-webmvc-spring-boot-starter/build.gradle
+++ b/nrich-webmvc-spring-boot-starter/build.gradle
@@ -7,14 +7,15 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
   compileOnly "org.projectlombok:lombok"
 
-  implementation project(":nrich-logging")
   implementation project(":nrich-spring-boot")
   implementation project(":nrich-webmvc")
 
+  runtimeOnly project(":nrich-logging-spring-boot-starter")
   runtimeOnly project(":nrich-notification-spring-boot-starter")
 
   implementation "org.springframework.boot:spring-boot-autoconfigure"
 
+  testImplementation project(":nrich-logging-spring-boot-starter")
   testImplementation project(":nrich-notification-spring-boot-starter")
 
   testRuntimeOnly "ch.qos.logback:logback-classic"

--- a/nrich-webmvc-spring-boot-starter/src/main/java/net/croz/nrich/webmvc/starter/configuration/NrichWebMvcAutoConfiguration.java
+++ b/nrich-webmvc-spring-boot-starter/src/main/java/net/croz/nrich/webmvc/starter/configuration/NrichWebMvcAutoConfiguration.java
@@ -1,7 +1,6 @@
 package net.croz.nrich.webmvc.starter.configuration;
 
 import net.croz.nrich.logging.api.service.LoggingService;
-import net.croz.nrich.logging.service.Slf4jLoggingService;
 import net.croz.nrich.notification.api.service.BaseNotificationResponseService;
 import net.croz.nrich.springboot.condition.ConditionalOnPropertyNotEmpty;
 import net.croz.nrich.webmvc.advice.ControllerEditorRegistrationAdvice;
@@ -49,12 +48,6 @@ public class NrichWebMvcAutoConfiguration {
     @Bean
     public ExceptionHttpStatusResolverService exceptionHttpStatusResolverService(MessageSource messageSource) {
         return new MessageSourceExceptionHttpStatusResolverService(messageSource);
-    }
-
-    @ConditionalOnMissingBean
-    @Bean
-    public LoggingService loggingService(MessageSource messageSource) {
-        return new Slf4jLoggingService(messageSource);
     }
 
     @ConditionalOnProperty(name = "nrich.webmvc.controller-advice-enabled", havingValue = "true", matchIfMissing = true)

--- a/nrich-webmvc-spring-boot-starter/src/test/java/net/croz/nrich/webmvc/starter/configuration/NrichWebMvcAutoConfigurationTest.java
+++ b/nrich-webmvc-spring-boot-starter/src/test/java/net/croz/nrich/webmvc/starter/configuration/NrichWebMvcAutoConfigurationTest.java
@@ -1,6 +1,7 @@
 package net.croz.nrich.webmvc.starter.configuration;
 
 import net.croz.nrich.logging.api.service.LoggingService;
+import net.croz.nrich.logging.starter.configuration.NrichLoggingAutoConfiguration;
 import net.croz.nrich.notification.starter.configuration.NrichNotificationAutoConfiguration;
 import net.croz.nrich.webmvc.advice.ControllerEditorRegistrationAdvice;
 import net.croz.nrich.webmvc.advice.NotificationErrorHandlingRestControllerAdvice;
@@ -18,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NrichWebMvcAutoConfigurationTest {
 
     private final WebApplicationContextRunner webApplicationContextRunner = new WebApplicationContextRunner()
-        .withConfiguration(AutoConfigurations.of(NrichNotificationAutoConfiguration.class, NrichWebMvcAutoConfiguration.class));
+        .withConfiguration(AutoConfigurations.of(NrichLoggingAutoConfiguration.class, NrichNotificationAutoConfiguration.class, NrichWebMvcAutoConfiguration.class));
 
     @Test
     void shouldConfigureDefaultConfiguration() {
@@ -37,18 +38,16 @@ class NrichWebMvcAutoConfigurationTest {
     @Test
     void shouldAddConstrainedLocaleResolverWhenAllowedLocaleListIsNotEmpty() {
         // expect
-        webApplicationContextRunner.withPropertyValues("nrich.webmvc.allowed-locale-list=hr,en")
-            .withBean(ResourceBundleMessageSource.class).run(context ->
-                assertThat(context).hasSingleBean(ConstrainedSessionLocaleResolver.class)
-            );
+        webApplicationContextRunner.withPropertyValues("nrich.webmvc.allowed-locale-list=hr,en").withBean(ResourceBundleMessageSource.class).run(context ->
+            assertThat(context).hasSingleBean(ConstrainedSessionLocaleResolver.class)
+        );
     }
 
     @Test
     void shouldNotAddAdviceWhenItsDisabled() {
         // expect
-        webApplicationContextRunner.withPropertyValues("nrich.webmvc.controller-advice-enabled=false")
-            .withBean(ResourceBundleMessageSource.class).run(context ->
-                assertThat(context).doesNotHaveBean(NotificationErrorHandlingRestControllerAdvice.class)
-            );
+        webApplicationContextRunner.withPropertyValues("nrich.webmvc.controller-advice-enabled=false").withBean(ResourceBundleMessageSource.class).run(context ->
+            assertThat(context).doesNotHaveBean(NotificationErrorHandlingRestControllerAdvice.class)
+        );
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ include(
   "nrich-jackson-spring-boot-starter",
   "nrich-logging-api",
   "nrich-logging",
+  "nrich-logging-spring-boot-starter",
   "nrich-notification-api",
   "nrich-notification",
   "nrich-notification-spring-boot-starter",


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.3.0
* Module:
nrich-logging

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Added Spring Boot starter module for nrich-logging, changed nrich-webmvc-spring-boot-starter dependencies to use that starter instead of manually creating LoggingService bean.

### Details

Added Spring Boot starter module for nrich-logging, changed nrich-webmvc-spring-boot-starter dependencies to use that starter instead of manually creating LoggingService bean.

### Related issue
https://github.com/croz-ltd/nrich/issues/32

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- New feature (non-breaking change which adds functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
