### PR TITLE
Add Notification timestamp to allow frontend display and easier handling

### DIFF
--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/model/Notification.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/model/Notification.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -57,4 +58,8 @@ public class Notification {
      */
     private final Map<String, ?> uxNotificationOptions;
 
+    /**
+     * Timestamp of the notification.
+     */
+    private final Instant timestamp = Instant.now();
 }

--- a/nrich-webmvc-spring-boot-starter/build.gradle
+++ b/nrich-webmvc-spring-boot-starter/build.gradle
@@ -13,6 +13,8 @@ dependencies {
   runtimeOnly project(":nrich-logging-spring-boot-starter")
   runtimeOnly project(":nrich-notification-spring-boot-starter")
 
+  runtimeOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+
   implementation "org.springframework.boot:spring-boot-autoconfigure"
 
   testImplementation project(":nrich-logging-spring-boot-starter")

--- a/nrich-webmvc/build.gradle
+++ b/nrich-webmvc/build.gradle
@@ -12,6 +12,8 @@ dependencies {
   implementation "jakarta.validation:jakarta.validation-api"
   implementation "org.springframework:spring-webmvc"
 
+  runtimeOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+
   testAnnotationProcessor "org.projectlombok:lombok"
   testCompileOnly "org.projectlombok:lombok"
 

--- a/nrich-webmvc/src/test/java/net/croz/nrich/webmvc/advice/NotificationErrorHandlingRestControllerAdviceTest.java
+++ b/nrich-webmvc/src/test/java/net/croz/nrich/webmvc/advice/NotificationErrorHandlingRestControllerAdviceTest.java
@@ -37,6 +37,8 @@ class NotificationErrorHandlingRestControllerAdviceTest extends BaseControllerTe
 
     private static final String NOTIFICATION_VALIDATION_ERROR_LIST_PATH = "$.notification.validationErrorList[0]";
 
+    private static final String NOTIFICATION_TIMESTAMP_PATH = "$.notification.timestamp";
+
     @Test
     void shouldResolveExceptionNotification() throws Exception {
         // given
@@ -49,7 +51,8 @@ class NotificationErrorHandlingRestControllerAdviceTest extends BaseControllerTe
         result.andExpect(status().isBadGateway())
             .andExpect(jsonPath(NOTIFICATION_TITLE_PATH).value("Error"))
             .andExpect(jsonPath(NOTIFICATION_CONTENT_PATH).value("Error message"))
-            .andExpect(jsonPath(NOTIFICATION_MESSAGE_LIST_PATH).value(startsWith("UUID")));
+            .andExpect(jsonPath(NOTIFICATION_MESSAGE_LIST_PATH).value(startsWith("UUID")))
+            .andExpect(jsonPath(NOTIFICATION_TIMESTAMP_PATH).isNotEmpty());
     }
 
     @Test


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.4.0
* Module:
nrich-notification-api, nrich-webmvc,  nrich-webmvc-spring-boot-starter

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Added notification timestamp to allow frontend display and easier handling (can be used as key when using React as frontend)

### Details

Added notification timestamp to allow frontend display and easier handling (can be used as key when using React as frontend)

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
-  ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
