### PR TITLE
Refactor SearchExecutorJpaRepositoryFactoryBean initialization

### DIFF
--- a/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/factory/SearchExecutorJpaRepositoryFactoryBean.java
+++ b/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/factory/SearchExecutorJpaRepositoryFactoryBean.java
@@ -17,6 +17,7 @@
 
 package net.croz.nrich.search.api.factory;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
@@ -32,14 +33,27 @@ import javax.persistence.EntityManager;
  */
 public class SearchExecutorJpaRepositoryFactoryBean<T extends Repository<S, I>, S, I> extends JpaRepositoryFactoryBean<T, S, I> {
 
-    private final RepositoryFactorySupportFactory repositoryFactorySupportFactory;
+    private RepositoryFactorySupportFactory repositoryFactorySupportFactory;
+
+    private BeanFactory beanFactory;
 
     private final Class<? extends T> repositoryInterface;
 
-    public SearchExecutorJpaRepositoryFactoryBean(Class<? extends T> repositoryInterface, RepositoryFactorySupportFactory repositoryFactorySupportFactory) {
+    public SearchExecutorJpaRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
         super(repositoryInterface);
         this.repositoryInterface = repositoryInterface;
-        this.repositoryFactorySupportFactory = repositoryFactorySupportFactory;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        this.repositoryFactorySupportFactory = beanFactory.getBean(RepositoryFactorySupportFactory.class);
+        super.afterPropertiesSet();
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+        super.setBeanFactory(beanFactory);
     }
 
     @Override

--- a/nrich-search/src/test/java/net/croz/nrich/search/factory/SearchExecutorJpaRepositoryFactoryBeanIntegrationTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/factory/SearchExecutorJpaRepositoryFactoryBeanIntegrationTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2020-2022 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.search.factory;
+
+import net.croz.nrich.search.factory.stub.SearchGetBeanConfiguration;
+import net.croz.nrich.search.SearchTestConfiguration;
+import net.croz.nrich.search.repository.stub.TestEntitySearchRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig(classes = { SearchGetBeanConfiguration.class, SearchTestConfiguration.class })
+class SearchExecutorJpaRepositoryFactoryBeanIntegrationTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void shouldCreateRepositoryWhenThereAreGetBeanCallsInConfiguration() {
+        // when
+        TestEntitySearchRepository result = applicationContext.getBean(TestEntitySearchRepository.class);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+}

--- a/nrich-search/src/test/java/net/croz/nrich/search/factory/stub/SearchGetBeanConfiguration.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/factory/stub/SearchGetBeanConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2020-2022 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.search.factory.stub;
+
+import net.croz.nrich.search.repository.stub.TestEntitySearchRepository;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Configuration(proxyBeanMethods = false)
+public class SearchGetBeanConfiguration implements BeanFactoryPostProcessor {
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory configurableListableBeanFactory) throws BeansException {
+        configurableListableBeanFactory.getBean(TestEntitySearchRepository.class);
+    }
+}


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
 1.4.0
* Module:
nrich-search

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Refactored `SearchExecutorJpaRepositoryFactoryBean` initialization by moving constructor dependency resolving to `afterPropertiesSet` method.

### Details

Refactored `SearchExecutorJpaRepositoryFactoryBean` initialization by moving constructor dependency resolving to `afterPropertiesSet` method since the former fails when there are `getBean` calls before initialization is complete.


### Related issue

https://github.com/croz-ltd/nrich/issues/117

## Types of changes


- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
-  ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
