### PR TITLE
Add HTTP method when resolving notifications from request since HTTP …

### DIFF
--- a/nrich-notification-spring-boot-starter/README.md
+++ b/nrich-notification-spring-boot-starter/README.md
@@ -64,16 +64,16 @@ format. If users want to return all the responses in a standard way they should 
 An example is given bellow:
 
 ```java
-@RestController("user")
 @RequiredArgsConstructor
+@RestController("user")
 public class UserController {
 
-    private final NotificationResponseService<ResponseWithNotification<?>> notificationResponseService;
+    private final WebMvcNotificationResponseService notificationResponseService;
 
     private final UserService userService;
 
     @PostMapping
-    public ResponseWithNotification<?> save(CreateUserRequest request) {
+    public NotificationDataResponse<?> save(CreateUserRequest request) {
         User saved = userService.save(request);
 
         return notificationResponseService.responseWithNotificationActionResolvedFromRequest(saved);

--- a/nrich-notification/README.md
+++ b/nrich-notification/README.md
@@ -324,15 +324,17 @@ Manual providing of action code is recommended when automatic resolving from the
 Example of manual providing:
 
 ```java
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("notification-example")
 public class ExampleController {
+
+    private final NotificationResponseService notificationResponseService;
 
     @GetMapping("manual")
     public NotificationResponse manualExample() {
         return notificationResponseService.responseWithNotification("manual.example");
     }
-
 }
 ```
 
@@ -361,13 +363,30 @@ response is:
 #### Automatic resolving
 
 Automatic resolving of the notification action code was used in chapter describing the action notification. Method `responseWithNotificationActionResolvedFromRequest` will resolve the action code from
-current request and the key for resolving title and content is: `notification-example.save`.
+current request and HTTP method and the key for resolving title and content is: `notification-example.save.post`.
+
+Example of automatic resolving:
+
+```java
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("notification-example")
+public class ExampleController {
+
+    private final NotificationResponseService notificationResponseService;
+
+    @PostMapping("save")
+    public NotificationResponse automaticExample() {
+        return notificationResponseService.responseWithNotificationActionResolvedFromRequest();
+    }
+}
+```
 
 If we were to put these key-value pairs into the `messages.properties` file:
 
 ```properties
-notification-example.save.title=Automatic resolution title
-notification-example.save.content=Automatic resolution content
+notification-example.save.post.title=Automatic resolution title
+notification-example.save.post.content=Automatic resolution content
 ```
 
 then the response that we would receive would be different from the one already seen:

--- a/nrich-notification/src/main/java/net/croz/nrich/notification/service/WebMvcNotificationResponseService.java
+++ b/nrich-notification/src/main/java/net/croz/nrich/notification/service/WebMvcNotificationResponseService.java
@@ -32,6 +32,7 @@ import org.springframework.web.util.UrlPathHelper;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
+import java.util.Locale;
 import java.util.Objects;
 
 @RequiredArgsConstructor
@@ -95,8 +96,9 @@ public class WebMvcNotificationResponseService implements NotificationResponseSe
 
     private String extractActionNameFromCurrentRequest() {
         HttpServletRequest request = ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder.getRequestAttributes())).getRequest();
+        String method = request.getMethod().toLowerCase(Locale.ROOT);
 
-        return extractActionNameFromRequest(request);
+        return String.format(NotificationConstants.PREFIX_MESSAGE_FORMAT, extractActionNameFromRequest(request), method);
     }
 
     private String extractActionNameFromRequest(HttpServletRequest request) {

--- a/nrich-notification/src/test/java/net/croz/nrich/notification/service/WebMvcNotificationResponseServiceTest.java
+++ b/nrich-notification/src/test/java/net/croz/nrich/notification/service/WebMvcNotificationResponseServiceTest.java
@@ -57,6 +57,7 @@ class WebMvcNotificationResponseServiceTest {
         );
 
         when(notificationResolverService.createNotificationForAction(eq("actionPrefix.actionSuffix"), any(AdditionalNotificationData.class))).thenReturn(firstNotification);
+        when(notificationResolverService.createNotificationForAction(eq("actionPrefix.actionSuffix.post"), any(AdditionalNotificationData.class))).thenReturn(firstNotification);
         when(notificationResolverService.createNotificationForValidationFailure(any(Errors.class), any(), any(AdditionalNotificationData.class))).thenReturn(firstValidationNotification);
         when(notificationResolverService.createNotificationForValidationFailure(any(ConstraintViolationException.class), any(AdditionalNotificationData.class))).thenReturn(secondValidationNotification);
         when(notificationResolverService.createNotificationForException(any(Throwable.class), any(AdditionalNotificationData.class))).thenReturn(secondNotification);

--- a/nrich-notification/src/test/resources/messages.properties
+++ b/nrich-notification/src/test/resources/messages.properties
@@ -27,4 +27,4 @@ upload.finished.content=Upload finished
 upload.finished.with-title.content=Upload finished
 upload.finished.with-title.title=Custom title
 
-actionPrefix.actionSuffix.content=Action success
+actionPrefix.actionSuffix.post.content=Action success


### PR DESCRIPTION
…endpoints might match by path and differ only by method

<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.4.1
* Module:
nrich-notification

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Added HTTP method to message code used for resolving notifications from request. Now previous code that was resolved through path also has method suffix i.e (users.get).

### Details

Added HTTP method to message code used for resolving notifications from request. Now previous code that was resolved through path also has method suffix i.e (users.get).

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Breaking change (fix, enhancement or feature that would cause existing functionality to change in backward-incompatible way)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
