### PR TITLE
Feature improvements for native image run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ subprojects { Project subproject ->
 
     tasks.withType(JavaCompile) {
       options.encoding = "UTF-8"
+      options.compilerArgs << "-parameters"
     }
 
     parent.dependencies {

--- a/nrich-form-configuration-spring-boot-starter/src/main/java/net/croz/nrich/formconfiguration/starter/configuration/NrichFormConfigurationAutoConfiguration.java
+++ b/nrich-form-configuration-spring-boot-starter/src/main/java/net/croz/nrich/formconfiguration/starter/configuration/NrichFormConfigurationAutoConfiguration.java
@@ -41,13 +41,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.util.CollectionUtils;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
+import javax.validation.Validator;
 import java.util.List;
 import java.util.Map;
 
 @AutoConfigureAfter(ValidationAutoConfiguration.class)
-@ConditionalOnBean(LocalValidatorFactoryBean.class)
+@ConditionalOnBean(Validator.class)
 @EnableConfigurationProperties(NrichFormConfigurationProperties.class)
 @Configuration(proxyBeanMethods = false)
 public class NrichFormConfigurationAutoConfiguration {
@@ -73,7 +73,7 @@ public class NrichFormConfigurationAutoConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    public FormConfigurationService formConfigurationService(@Lazy LocalValidatorFactoryBean validator, NrichFormConfigurationProperties configurationProperties,
+    public FormConfigurationService formConfigurationService(@Lazy Validator validator, NrichFormConfigurationProperties configurationProperties,
                                                              List<ConstrainedPropertyValidatorConverterService> constrainedPropertyValidatorConverterServiceList,
                                                              FormConfigurationAnnotationResolvingService formConfigurationAnnotationResolvingService,
                                                              @Autowired(required = false) List<FormConfigurationMappingCustomizer> formConfigurationCustomizerList) {


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
 1.4.1
* Module:
project
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Make required changes to enable easier native image running.

### Details

Add parameters to compile java task to be able to use @ConfigurationProperties classes, use Validator interface instead of an implementation.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- Enhancement (non-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix, enhancement or feature that would cause existing functionality to change in backward-incompatible way)
- Docs change
- Refactoring
- Dependency upgrade

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
