### PR TITLE
Feature allow for javascript type customization

### DIFF
--- a/nrich-form-configuration-api/build.gradle
+++ b/nrich-form-configuration-api/build.gradle
@@ -1,7 +1,7 @@
 description = "Nrich Form Configuration API"
 
 dependencies {
-  api project(":nrich-javascript")
+  api project(":nrich-javascript-api")
   api "jakarta.validation:jakarta.validation-api"
 
   annotationProcessor "org.projectlombok:lombok"

--- a/nrich-form-configuration-api/src/main/java/net/croz/nrich/formconfiguration/api/model/ConstrainedPropertyConfiguration.java
+++ b/nrich-form-configuration-api/src/main/java/net/croz/nrich/formconfiguration/api/model/ConstrainedPropertyConfiguration.java
@@ -19,7 +19,6 @@ package net.croz.nrich.formconfiguration.api.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.croz.nrich.javascript.model.JavascriptType;
 
 import java.util.List;
 
@@ -43,7 +42,7 @@ public class ConstrainedPropertyConfiguration {
     /**
      * Javascript type of constrained property.
      */
-    private final JavascriptType javascriptType;
+    private final String javascriptType;
 
     /**
      * List of {@link ConstrainedPropertyClientValidatorConfiguration} instances that hold client side validation configuration.

--- a/nrich-form-configuration-spring-boot-starter/README.md
+++ b/nrich-form-configuration-spring-boot-starter/README.md
@@ -44,6 +44,7 @@ readability):
 | property                                            | description                                                                                                                                                                                                                                                                                                                                                   | default value |
 |-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | default-converter-enabled                           | whether default converter service [`DefaultConstrainedPropertyValidatorConverterService`][default-constrained-property-validator-converter-service-url] for converting [`ConstrainedProperty`][constrained-property-url] instances to [`ConstrainedPropertyClientValidatorConfiguration`][constrained-property-client-validator-configuration-url] is enabled | true          |
+| default-java-to-javascript-converter-enabled        | whether default Java to Javascript type converter is enabled                                                                                                                                                                                                                                                                                                  | true          |
 | form-configuration-mapping                          | mapping between a client side form identifier and class holding the constraints for the form (usually the class accepted as input on the server side)                                                                                                                                                                                                         |               |
 | form-validation-configuration-classes-package-list  | optional packages to scan for [`@FormValidationConfiguration`][form-configuration-annotation-url] annotated classes it can be used instead of form-configuration-mapping                                                                                                                                                                                      |               |
 
@@ -52,6 +53,7 @@ The default configuration values are given bellow in a yaml format for easier mo
 ```yaml
 nrich.form-configuration:
   default-converter-enabled: true
+  default-java-to-javascript-converter-enabled: true
   form-configuration-mapping:
   form-validation-configuration-classes-package-list:
 ```

--- a/nrich-form-configuration-spring-boot-starter/build.gradle
+++ b/nrich-form-configuration-spring-boot-starter/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compileOnly "org.projectlombok:lombok"
 
   implementation project(":nrich-form-configuration")
+  implementation project(":nrich-javascript")
 
   implementation "org.springframework.boot:spring-boot-autoconfigure"
 

--- a/nrich-form-configuration-spring-boot-starter/src/main/java/net/croz/nrich/formconfiguration/starter/properties/NrichFormConfigurationProperties.java
+++ b/nrich-form-configuration-spring-boot-starter/src/main/java/net/croz/nrich/formconfiguration/starter/properties/NrichFormConfigurationProperties.java
@@ -38,6 +38,11 @@ public class NrichFormConfigurationProperties {
     private final boolean defaultConverterEnabled;
 
     /**
+     * Whether default Java to Javascript type converter ({@link net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter}) used for converting Java to Javascript types is enabled.
+     */
+    private final boolean defaultJavaToJavascriptConverterEnabled;
+
+    /**
      * Mapping between a client side form identifier and class holding the constraints for the form (usually the class accepted as input on the server side).
      */
     private final Map<String, Class<?>> formConfigurationMapping;
@@ -47,9 +52,10 @@ public class NrichFormConfigurationProperties {
      */
     private final List<String> formValidationConfigurationClassesPackageList;
 
-    public NrichFormConfigurationProperties(@DefaultValue("true") boolean defaultConverterEnabled, Map<String, Class<?>> formConfigurationMapping,
-                                            List<String> formValidationConfigurationClassesPackageList) {
+    public NrichFormConfigurationProperties(@DefaultValue("true") boolean defaultConverterEnabled, @DefaultValue("true") boolean defaultJavaToJavascriptConverterEnabled,
+                                            Map<String, Class<?>> formConfigurationMapping, List<String> formValidationConfigurationClassesPackageList) {
         this.defaultConverterEnabled = defaultConverterEnabled;
+        this.defaultJavaToJavascriptConverterEnabled = defaultJavaToJavascriptConverterEnabled;
         this.formConfigurationMapping = formConfigurationMapping;
         this.formValidationConfigurationClassesPackageList = formValidationConfigurationClassesPackageList;
     }

--- a/nrich-form-configuration-spring-boot-starter/src/test/java/net/croz/nrich/formconfiguration/starter/configuration/NrichFormConfigurationAutoConfigurationTest.java
+++ b/nrich-form-configuration-spring-boot-starter/src/test/java/net/croz/nrich/formconfiguration/starter/configuration/NrichFormConfigurationAutoConfigurationTest.java
@@ -25,6 +25,8 @@ import net.croz.nrich.formconfiguration.controller.FormConfigurationController;
 import net.croz.nrich.formconfiguration.service.FieldErrorMessageResolverService;
 import net.croz.nrich.formconfiguration.starter.configuration.stub.FormConfigurationTestRequest;
 import net.croz.nrich.formconfiguration.starter.properties.NrichFormConfigurationProperties;
+import net.croz.nrich.javascript.api.converter.JavaToJavascriptTypeConverter;
+import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -49,6 +51,7 @@ class NrichFormConfigurationAutoConfigurationTest {
             assertThat(context).hasSingleBean(FieldErrorMessageResolverService.class);
             assertThat(context).hasSingleBean(FormConfigurationService.class);
             assertThat(context).hasSingleBean(FormConfigurationController.class);
+            assertThat(context).hasSingleBean(JavaToJavascriptTypeConversionService.class);
         });
     }
 
@@ -67,6 +70,14 @@ class NrichFormConfigurationAutoConfigurationTest {
         // expect
         contextRunner.withBean(LocalValidatorFactoryBean.class).withPropertyValues("nrich.form-configuration.default-converter-enabled=false").run(context ->
             assertThat(context).doesNotHaveBean(ConstrainedPropertyValidatorConverterService.class)
+        );
+    }
+
+    @Test
+    void shouldNotCreateDefaultJavaToJavascriptConverterWhenCreationIsDisabled() {
+        // expect
+        contextRunner.withBean(LocalValidatorFactoryBean.class).withPropertyValues("nrich.form-configuration.default-java-to-javascript-converter-enabled=false").run(context ->
+            assertThat(context).doesNotHaveBean(JavaToJavascriptTypeConverter.class)
         );
     }
 

--- a/nrich-form-configuration/build.gradle
+++ b/nrich-form-configuration/build.gradle
@@ -6,6 +6,8 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
   compileOnly "org.projectlombok:lombok"
 
+  implementation project(":nrich-javascript")
+
   implementation "org.springframework:spring-context"
 
   webMvcImplementation "com.fasterxml.jackson.core:jackson-databind"

--- a/nrich-form-configuration/src/main/java/net/croz/nrich/formconfiguration/service/DefaultFormConfigurationService.java
+++ b/nrich-form-configuration/src/main/java/net/croz/nrich/formconfiguration/service/DefaultFormConfigurationService.java
@@ -24,8 +24,7 @@ import net.croz.nrich.formconfiguration.api.model.ConstrainedPropertyConfigurati
 import net.croz.nrich.formconfiguration.api.model.FormConfiguration;
 import net.croz.nrich.formconfiguration.api.service.ConstrainedPropertyValidatorConverterService;
 import net.croz.nrich.formconfiguration.api.service.FormConfigurationService;
-import net.croz.nrich.javascript.model.JavascriptType;
-import net.croz.nrich.javascript.util.JavaToJavascriptTypeConversionUtil;
+import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import org.springframework.cache.annotation.Cacheable;
 
 import javax.validation.Validator;
@@ -50,6 +49,8 @@ public class DefaultFormConfigurationService implements FormConfigurationService
     private final Map<String, Class<?>> formIdConstraintHolderMap;
 
     private final List<ConstrainedPropertyValidatorConverterService> constraintConverterServiceList;
+
+    private final JavaToJavascriptTypeConversionService javaToJavascriptTypeConversionService;
 
     @Cacheable(value = "nrich.formConfiguration.cache", key = "'all-forms-' + T(org.springframework.context.i18n.LocaleContextHolder).locale.toLanguageTag()")
     @Override
@@ -87,7 +88,7 @@ public class DefaultFormConfigurationService implements FormConfigurationService
 
             if (!constrainedPropertyClientValidatorConfigurationList.isEmpty()) {
                 Class<?> propertyType = propertyDescriptor.getElementClass();
-                JavascriptType javascriptType = JavaToJavascriptTypeConversionUtil.fromJavaType(propertyType);
+                String javascriptType = javaToJavascriptTypeConversionService.convert(propertyType);
                 constrainedPropertyConfigurationList.add(
                     new ConstrainedPropertyConfiguration(propertyPath, propertyType, javascriptType, constrainedPropertyClientValidatorConfigurationList)
                 );

--- a/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/FormConfigurationTestConfiguration.java
+++ b/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/FormConfigurationTestConfiguration.java
@@ -28,6 +28,9 @@ import net.croz.nrich.formconfiguration.service.MessageSourceFieldErrorMessageRe
 import net.croz.nrich.formconfiguration.stub.FormConfigurationServiceNestedIgnoredTestRequest;
 import net.croz.nrich.formconfiguration.stub.FormConfigurationServiceNestedTestRequest;
 import net.croz.nrich.formconfiguration.stub.FormConfigurationServiceTestRequest;
+import net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter;
+import net.croz.nrich.javascript.service.DefaultJavaToJavascriptTypeConversionService;
+import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -73,15 +76,21 @@ public class FormConfigurationTestConfiguration {
     }
 
     @Bean
+    public JavaToJavascriptTypeConversionService javaToJavascriptTypeConversionService() {
+        return new DefaultJavaToJavascriptTypeConversionService(Collections.singletonList(new DefaultJavaToJavascriptTypeConverter()));
+    }
+
+    @Bean
     public FormConfigurationService formConfigurationService(LocalValidatorFactoryBean validator, List<ConstrainedPropertyValidatorConverterService> constrainedPropertyValidatorConverterServiceList,
-                                                             FormConfigurationAnnotationResolvingService formConfigurationAnnotationResolvingService) {
+                                                             FormConfigurationAnnotationResolvingService formConfigurationAnnotationResolvingService,
+                                                             JavaToJavascriptTypeConversionService javaToJavascriptTypeConversionService) {
         Map<String, Class<?>> formIdConstraintHolderMap = new LinkedHashMap<>(formConfigurationAnnotationResolvingService.resolveFormConfigurations(Collections.singletonList("net.croz")));
 
         formIdConstraintHolderMap.put(SIMPLE_FORM_CONFIGURATION_FORM_ID, FormConfigurationServiceTestRequest.class);
         formIdConstraintHolderMap.put(NESTED_FORM_CONFIGURATION_FORM_ID, FormConfigurationServiceNestedTestRequest.class);
         formIdConstraintHolderMap.put(NESTED_FORM_NOT_VALIDATED_CONFIGURATION_FORM_ID, FormConfigurationServiceNestedIgnoredTestRequest.class);
 
-        return new DefaultFormConfigurationService(validator.getValidator(), formIdConstraintHolderMap, constrainedPropertyValidatorConverterServiceList);
+        return new DefaultFormConfigurationService(validator.getValidator(), formIdConstraintHolderMap, constrainedPropertyValidatorConverterServiceList, javaToJavascriptTypeConversionService);
     }
 
     @Bean

--- a/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/service/DefaultFormConfigurationServiceTest.java
+++ b/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/service/DefaultFormConfigurationServiceTest.java
@@ -21,7 +21,6 @@ import net.croz.nrich.formconfiguration.FormConfigurationTestConfiguration;
 import net.croz.nrich.formconfiguration.api.model.ConstrainedPropertyClientValidatorConfiguration;
 import net.croz.nrich.formconfiguration.api.model.ConstrainedPropertyConfiguration;
 import net.croz.nrich.formconfiguration.api.model.FormConfiguration;
-import net.croz.nrich.javascript.model.JavascriptType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -86,7 +85,7 @@ class DefaultFormConfigurationServiceTest {
             "name", "lastName", "timestamp", "value"
         );
         assertThat(formConfiguration.getConstrainedPropertyConfigurationList()).extracting(ConstrainedPropertyConfiguration::getJavascriptType).containsExactlyInAnyOrder(
-            JavascriptType.STRING, JavascriptType.STRING, JavascriptType.DATE, JavascriptType.NUMBER
+            "string", "string", "date", "number"
         );
 
         // and when

--- a/nrich-javascript-api/README.md
+++ b/nrich-javascript-api/README.md
@@ -1,0 +1,9 @@
+# nrich-javascript-api
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.croz.nrich/nrich-javascript-api/badge.svg?color=blue)](https://maven-badges.herokuapp.com/maven-central/net.croz.nrich/nrich-javascript-api)
+
+## Overview
+
+This module contains classes that represent the API (interfaces and data classes) for [`nrich-javascript`](../nrich-javascript/README.md) module.
+It is used internally by `nrich-form-configuration` and `nrich-registry` modules.
+

--- a/nrich-javascript-api/build.gradle
+++ b/nrich-javascript-api/build.gradle
@@ -1,0 +1,1 @@
+description = "Nrich Javascript API"

--- a/nrich-javascript-api/src/main/java/net/croz/nrich/javascript/api/converter/JavaToJavascriptTypeConverter.java
+++ b/nrich-javascript-api/src/main/java/net/croz/nrich/javascript/api/converter/JavaToJavascriptTypeConverter.java
@@ -15,21 +15,15 @@
  *
  */
 
-package net.croz.nrich.javascript.model;
-
-import com.fasterxml.jackson.annotation.JsonValue;
-
-import java.util.Locale;
+package net.croz.nrich.javascript.api.converter;
 
 /**
- * Enum representing Javascript type, even though date is not a type it is added for easier handling on client.
+ * Converts Java class to Javascript representations. String is used to allow for customizations.
  */
-public enum JavascriptType {
+public interface JavaToJavascriptTypeConverter {
 
-    STRING, BOOLEAN, NUMBER, DATE, OBJECT;
+    boolean supports(Class<?> type);
 
-    @JsonValue
-    public String getName() {
-        return name().toLowerCase(Locale.ROOT);
-    }
+    String convert(Class<?> type);
+
 }

--- a/nrich-javascript-api/src/main/java/net/croz/nrich/javascript/api/model/JavascriptType.java
+++ b/nrich-javascript-api/src/main/java/net/croz/nrich/javascript/api/model/JavascriptType.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2020-2022 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.javascript.api.model;
+
+/**
+ * Enum representing Javascript type, even though date is not a type it is added for easier handling on client.
+ */
+public enum JavascriptType {
+
+    STRING, BOOLEAN, NUMBER, DATE, OBJECT
+
+}

--- a/nrich-javascript-api/src/main/java/net/croz/nrich/javascript/api/service/JavaToJavascriptTypeConversionService.java
+++ b/nrich-javascript-api/src/main/java/net/croz/nrich/javascript/api/service/JavaToJavascriptTypeConversionService.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2020-2022 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.javascript.api.service;
+
+/**
+ * Service responsible for conversion between Java and Javascript type. Default implementation delegates to a list of converters.
+ */
+public interface JavaToJavascriptTypeConversionService {
+
+    String convert(Class<?> type);
+
+}

--- a/nrich-javascript/README.MD
+++ b/nrich-javascript/README.MD
@@ -9,4 +9,11 @@ modules.
 
 ## Usage
 
-This module is primary internal to nrich. But if users want to use it for converting Java type to Javascript type the class `JavaToJavascriptTypeConversionUtil` should be used.
+This module is primary internal to nrich. But if users want to customize conversion of Java to Javascript type they can implement [`JavaToJavascriptTypeConverter`][converter-url]
+interface and override default behaviour. For default behaviour see [`DefaultJavaToJavascriptTypeConverter`][default-converter-url].
+
+[//]: # (Reference links)
+
+[converter-url]: ../nrich-javascript-api/src/main/java/net/croz/nrich/javascript/api/converter/JavaToJavascriptTypeConverter.java
+
+[default-converter-url]: ../nrich-javascript/src/main/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverter.java

--- a/nrich-javascript/build.gradle
+++ b/nrich-javascript/build.gradle
@@ -1,11 +1,19 @@
 description = "Nrich Javascript"
 
 dependencies {
-  implementation "com.fasterxml.jackson.core:jackson-annotations"
+  api project(":nrich-javascript-api")
 
+  implementation "org.slf4j:slf4j-api"
+  implementation "org.springframework:spring-core"
+
+  annotationProcessor "org.projectlombok:lombok"
+  compileOnly "org.projectlombok:lombok"
+
+  testRuntimeOnly "ch.qos.logback:logback-classic"
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"
+  testImplementation "org.mockito:mockito-junit-jupiter"
 }

--- a/nrich-javascript/src/main/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverter.java
+++ b/nrich-javascript/src/main/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverter.java
@@ -15,21 +15,21 @@
  *
  */
 
-package net.croz.nrich.javascript.util;
+package net.croz.nrich.javascript.converter;
 
-import net.croz.nrich.javascript.model.JavascriptType;
+import net.croz.nrich.javascript.api.converter.JavaToJavascriptTypeConverter;
+import net.croz.nrich.javascript.api.model.JavascriptType;
+import org.springframework.core.annotation.Order;
 
-import java.math.BigDecimal;
 import java.time.temporal.Temporal;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
-/**
- * Converts Java class to Javascript representations.
- */
-public final class JavaToJavascriptTypeConversionUtil {
+@Order
+public class DefaultJavaToJavascriptTypeConverter implements JavaToJavascriptTypeConverter {
 
     private static final Map<Class<?>, JavascriptType> CLASS_JAVASCRIPT_TYPE_MAP = new HashMap<>();
 
@@ -43,23 +43,18 @@ public final class JavaToJavascriptTypeConversionUtil {
         CLASS_JAVASCRIPT_TYPE_MAP.put(Number.class, JavascriptType.NUMBER);
     }
 
-    private JavaToJavascriptTypeConversionUtil() {
+    @Override
+    public boolean supports(Class<?> type) {
+        return true;
     }
 
-    public static JavascriptType fromJavaType(Class<?> type) {
+    @Override
+    public String convert(Class<?> type) {
         return CLASS_JAVASCRIPT_TYPE_MAP.entrySet().stream()
             .filter(entry -> entry.getKey().isAssignableFrom(type))
             .findFirst()
             .map(Map.Entry::getValue)
-            .orElse(JavascriptType.OBJECT);
-    }
-
-    /**
-     * Whether the type is decimal.
-     * @param type Type to check.
-     * @return true if type is decimal
-     */
-    public static boolean isDecimal(Class<?> type) {
-        return type.isAssignableFrom(BigDecimal.class) || type.isAssignableFrom(Float.class) || type.isAssignableFrom(Double.class);
+            .orElse(JavascriptType.OBJECT)
+            .name().toLowerCase(Locale.ROOT);
     }
 }

--- a/nrich-javascript/src/main/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverter.java
+++ b/nrich-javascript/src/main/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverter.java
@@ -41,6 +41,7 @@ public class DefaultJavaToJavascriptTypeConverter implements JavaToJavascriptTyp
         CLASS_JAVASCRIPT_TYPE_MAP.put(Date.class, JavascriptType.DATE);
         CLASS_JAVASCRIPT_TYPE_MAP.put(Temporal.class, JavascriptType.DATE);
         CLASS_JAVASCRIPT_TYPE_MAP.put(Number.class, JavascriptType.NUMBER);
+        CLASS_JAVASCRIPT_TYPE_MAP.put(Enum.class, JavascriptType.STRING);
     }
 
     @Override

--- a/nrich-javascript/src/main/java/net/croz/nrich/javascript/service/DefaultJavaToJavascriptTypeConversionService.java
+++ b/nrich-javascript/src/main/java/net/croz/nrich/javascript/service/DefaultJavaToJavascriptTypeConversionService.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2020-2022 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.javascript.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.croz.nrich.javascript.api.converter.JavaToJavascriptTypeConverter;
+import net.croz.nrich.javascript.api.model.JavascriptType;
+import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.Locale;
+
+@Slf4j
+@RequiredArgsConstructor
+public class DefaultJavaToJavascriptTypeConversionService implements JavaToJavascriptTypeConversionService {
+
+    private static final String DEFAULT_TYPE = JavascriptType.OBJECT.name().toLowerCase(Locale.ROOT);
+
+    private final List<JavaToJavascriptTypeConverter> javaToJavascriptTypeConverterList;
+
+    @Override
+    public String convert(Class<?> type) {
+        if (CollectionUtils.isEmpty(javaToJavascriptTypeConverterList)) {
+            log.warn("No converts registered for converting between Java to Javascript type, consider defining a bean of {} type", JavaToJavascriptTypeConverter.class.getName());
+
+            return DEFAULT_TYPE;
+        }
+
+        return javaToJavascriptTypeConverterList.stream()
+            .filter(converter -> converter.supports(type))
+            .findFirst()
+            .map(converter -> converter.convert(type))
+            .orElse(DEFAULT_TYPE);
+    }
+}

--- a/nrich-javascript/src/test/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverterTest.java
+++ b/nrich-javascript/src/test/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverterTest.java
@@ -18,6 +18,7 @@
 package net.croz.nrich.javascript.converter;
 
 import net.croz.nrich.javascript.api.model.JavascriptType;
+import net.croz.nrich.javascript.stub.TestEnum;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -69,7 +70,8 @@ class DefaultJavaToJavascriptTypeConverterTest {
             arguments(Date.class, JavascriptType.DATE),
             arguments(java.sql.Date.class, JavascriptType.DATE),
             arguments(Boolean.class, JavascriptType.BOOLEAN),
-            arguments(Object.class, JavascriptType.OBJECT)
+            arguments(Object.class, JavascriptType.OBJECT),
+            arguments(TestEnum.class, JavascriptType.STRING)
         );
     }
 }

--- a/nrich-javascript/src/test/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverterTest.java
+++ b/nrich-javascript/src/test/java/net/croz/nrich/javascript/converter/DefaultJavaToJavascriptTypeConverterTest.java
@@ -15,9 +15,9 @@
  *
  */
 
-package net.croz.nrich.javascript.util;
+package net.croz.nrich.javascript.converter;
 
-import net.croz.nrich.javascript.model.JavascriptType;
+import net.croz.nrich.javascript.api.model.JavascriptType;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,18 +30,21 @@ import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-class JavaToJavascriptTypeConversionUtilTest {
+class DefaultJavaToJavascriptTypeConverterTest {
+
+    private final DefaultJavaToJavascriptTypeConverter converter = new DefaultJavaToJavascriptTypeConverter();
 
     @MethodSource("shouldConvertJavaToJavascriptTypeMethodSource")
     @ParameterizedTest
     void shouldConvertJavaToJavascriptType(Class<?> javaType, JavascriptType javascriptType) {
         // when
-        JavascriptType result = JavaToJavascriptTypeConversionUtil.fromJavaType(javaType);
+        JavascriptType result = JavascriptType.valueOf(converter.convert(javaType).toUpperCase(Locale.ROOT));
 
         // then
         assertThat(result).isEqualTo(javascriptType);
@@ -67,27 +70,6 @@ class JavaToJavascriptTypeConversionUtilTest {
             arguments(java.sql.Date.class, JavascriptType.DATE),
             arguments(Boolean.class, JavascriptType.BOOLEAN),
             arguments(Object.class, JavascriptType.OBJECT)
-        );
-    }
-
-    @MethodSource("shouldReturnTrueIfNumberIsDecimalMethodSource")
-    @ParameterizedTest
-    void shouldReturnTrueIfNumberIsDecimal(Class<?> type, boolean isDecimal) {
-        // when
-        boolean result = JavaToJavascriptTypeConversionUtil.isDecimal(type);
-
-        // then
-        assertThat(result).isEqualTo(isDecimal);
-    }
-
-    private static Stream<Arguments> shouldReturnTrueIfNumberIsDecimalMethodSource() {
-        return Stream.of(
-            arguments(Integer.class, false),
-            arguments(Short.class, false),
-            arguments(Long.class, false),
-            arguments(Float.class, true),
-            arguments(Double.class, true),
-            arguments(BigDecimal.class, true)
         );
     }
 }

--- a/nrich-javascript/src/test/java/net/croz/nrich/javascript/service/DefaultJavaToJavascriptTypeConversionServiceTest.java
+++ b/nrich-javascript/src/test/java/net/croz/nrich/javascript/service/DefaultJavaToJavascriptTypeConversionServiceTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2020-2022 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.javascript.service;
+
+import net.croz.nrich.javascript.api.converter.JavaToJavascriptTypeConverter;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class DefaultJavaToJavascriptTypeConversionServiceTest {
+
+    @Test
+    void shouldReturnObjectWhenNoConvertersHaveBeenRegistered() {
+        // given
+        DefaultJavaToJavascriptTypeConversionService service = new DefaultJavaToJavascriptTypeConversionService(null);
+
+        // when
+        String result = service.convert(Integer.class);
+
+        // then
+        assertThat(result).isEqualTo("object");
+    }
+
+    @Test
+    void shouldConvertUsingRegisteredConverter() {
+        // given
+        Class<?> type = Integer.class;
+        JavaToJavascriptTypeConverter converter = mock(JavaToJavascriptTypeConverter.class);
+
+        doReturn(true).when(converter).supports(type);
+        doReturn("number").when(converter).convert(type);
+
+        DefaultJavaToJavascriptTypeConversionService service = new DefaultJavaToJavascriptTypeConversionService(Collections.singletonList(converter));
+
+        // when
+        String result = service.convert(type);
+
+        // then
+        assertThat(result).isEqualTo("number");
+
+        // and when
+        String resultWithoutConverter = service.convert(Object.class);
+
+        // then
+        assertThat(resultWithoutConverter).isEqualTo("object");
+    }
+}

--- a/nrich-javascript/src/test/java/net/croz/nrich/javascript/stub/TestEnum.java
+++ b/nrich-javascript/src/test/java/net/croz/nrich/javascript/stub/TestEnum.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright 2020-2022 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.javascript.stub;
+
+public enum TestEnum {
+
+    FIRST, SECOND
+
+}

--- a/nrich-registry-api/build.gradle
+++ b/nrich-registry-api/build.gradle
@@ -2,7 +2,7 @@ description = "Nrich Registry API"
 
 dependencies {
   api project(":nrich-search-api")
-  api project(":nrich-javascript")
+  api project(":nrich-javascript-api")
 
   annotationProcessor "org.projectlombok:lombok"
   compileOnly "org.projectlombok:lombok"

--- a/nrich-registry-api/src/main/java/net/croz/nrich/registry/api/configuration/model/property/RegistryPropertyConfiguration.java
+++ b/nrich-registry-api/src/main/java/net/croz/nrich/registry/api/configuration/model/property/RegistryPropertyConfiguration.java
@@ -19,7 +19,6 @@ package net.croz.nrich.registry.api.configuration.model.property;
 
 import lombok.Builder;
 import lombok.Getter;
-import net.croz.nrich.javascript.model.JavascriptType;
 
 /**
  * Represents client property configuration that can be used when building form and grids on client side.
@@ -34,9 +33,9 @@ public class RegistryPropertyConfiguration {
     private final String name;
 
     /**
-     * Property JavascriptType (converted from property type).
+     * Property Javascript type (converted from property type).
      */
-    private final JavascriptType javascriptType;
+    private final String javascriptType;
 
     /**
      * Property original type class name

--- a/nrich-registry-spring-boot-starter/README.md
+++ b/nrich-registry-spring-boot-starter/README.md
@@ -42,14 +42,15 @@ Note if using `nrich-bom` dependency versions should be omitted.
 
 Configuration is done through a property file, available properties and descriptions are given bellow (all properties are prefixed with nrich.registry which is omitted for readability):
 
-| property                                    | description                                                                                                                | default value                                             |
-|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
-| default-read-only-property-list             | List of property names that should always be marked as readonly                                                            |                                                           |
-| default-converter-enabled                   | Whether default string to type converter used for converting strings to property values when searching registry is enabled | true                                                      |
-| registry-search.date-format-list            | List of date formats used to convert string to date value                                                                  | dd.MM.yyyy., dd.MM.yyyy.'T'HH:mm, dd.MM.yyyy.'T'HH:mm'Z'  |
-| registry-search.decimal-number-format-list  | List of decimal formats used to convert string to decimal value                                                            | #0.00, #0,00                                              |
-| registry-search.boolean-true-regex-pattern  | Regexp pattern that is used to match boolean true values                                                                   | ^(?i)\s*(true&#124;yes&#124;da)\s*$                       |
-| registry-search.boolean-false-regex-pattern | Regexp pattern that is used to match boolean false values                                                                  | ^(?i)\s*(false&#124;no&#124;ne)\s*$                       |
+| property                                          | description                                                                                                                | default value                                             |
+|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| default-read-only-property-list                   | List of property names that should always be marked as readonly                                                            |                                                           |
+| default-converter-enabled                         | Whether default string to type converter used for converting strings to property values when searching registry is enabled | true                                                      |
+| default-java-to-javascript-converter-enabled      | Whether default Java to Javascript type converter is enabled                                                               | true                                                      |
+| registry-search.date-format-list                  | List of date formats used to convert string to date value                                                                  | dd.MM.yyyy., dd.MM.yyyy.'T'HH:mm, dd.MM.yyyy.'T'HH:mm'Z'  |
+| registry-search.decimal-number-format-list        | List of decimal formats used to convert string to decimal value                                                            | #0.00, #0,00                                              |
+| registry-search.boolean-true-regex-pattern        | Regexp pattern that is used to match boolean true values                                                                   | ^(?i)\s*(true&#124;yes&#124;da)\s*$                       |
+| registry-search.boolean-false-regex-pattern       | Regexp pattern that is used to match boolean false values                                                                  | ^(?i)\s*(false&#124;no&#124;ne)\s*$                       |
 
 The properties under registry-search are used when converting string received from client to property values that will be used to search registry. For example if a string is sent
 and the property searched by is of type Date, nrich will try to parse string to Date and if parsing succeeds restriction will be added to query and if parsing fails the property will be skipped
@@ -62,6 +63,7 @@ The default configuration values in yaml format for easier modification are give
 nrich.registry:
   default-read-only-property-list:
   default-converter-enabled: true
+  default-java-to-javascript-converter-enabled: true
   registry-search:
     date-format-list: dd.MM.yyyy., dd.MM.yyyy.'T'HH:mm, dd.MM.yyyy.'T'HH:mm'Z'
     decimal-number-format-list: #0.00, #0,00

--- a/nrich-registry-spring-boot-starter/build.gradle
+++ b/nrich-registry-spring-boot-starter/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
   compileOnly "org.projectlombok:lombok"
 
+  implementation project(":nrich-javascript")
   implementation project(":nrich-registry")
   implementation project(":nrich-spring-boot")
 

--- a/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/properties/NrichRegistryProperties.java
+++ b/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/properties/NrichRegistryProperties.java
@@ -46,15 +46,22 @@ public class NrichRegistryProperties {
     private final boolean defaultConverterEnabled;
 
     /**
+     * Whether default Java to Javascript type converter ({@link net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter}) used for converting Java to Javascript types is enabled.
+     */
+    private final boolean defaultJavaToJavascriptConverterEnabled;
+
+    /**
      * Registry configuration used for defining entities and groups which will be managed.
      */
     private final RegistryConfiguration registryConfiguration;
 
     public NrichRegistryProperties(List<String> defaultReadOnlyPropertyList, @DefaultValue RegistrySearchProperties registrySearch, @DefaultValue("true") boolean defaultConverterEnabled,
+                                   @DefaultValue("true") boolean defaultJavaToJavascriptConverterEnabled,
                                    RegistryConfiguration registryConfiguration) {
         this.defaultReadOnlyPropertyList = defaultReadOnlyPropertyList;
         this.registrySearch = registrySearch;
         this.defaultConverterEnabled = defaultConverterEnabled;
+        this.defaultJavaToJavascriptConverterEnabled = defaultJavaToJavascriptConverterEnabled;
         this.registryConfiguration = registryConfiguration;
     }
 

--- a/nrich-registry-spring-boot-starter/src/test/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfigurationTest.java
+++ b/nrich-registry-spring-boot-starter/src/test/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfigurationTest.java
@@ -19,6 +19,8 @@ package net.croz.nrich.registry.starter.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.croz.nrich.formconfiguration.api.customizer.FormConfigurationMappingCustomizer;
+import net.croz.nrich.javascript.api.converter.JavaToJavascriptTypeConverter;
+import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
 import net.croz.nrich.registry.api.core.model.RegistryConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryGroupDefinitionConfiguration;
@@ -142,6 +144,7 @@ class NrichRegistryAutoConfigurationTest {
             assertThat(context).hasSingleBean(RegistryDataRequestConversionService.class);
             assertThat(context).hasSingleBean(RegistryHistoryService.class);
             assertThat(context).hasSingleBean(FormConfigurationMappingCustomizer.class);
+            assertThat(context).hasSingleBean(JavaToJavascriptTypeConversionService.class);
 
             assertThat(context).doesNotHaveBean(RegistryConfigurationController.class);
             assertThat(context).doesNotHaveBean(RegistryDataController.class);
@@ -164,6 +167,15 @@ class NrichRegistryAutoConfigurationTest {
         contextRunner.withPropertyValues(REGISTRY_CONFIGURATION).withBean(LocalValidatorFactoryBean.class).withPropertyValues("nrich.registry.default-converter-enabled=false").run(context ->
             assertThat(context).doesNotHaveBean(StringToTypeConverter.class)
         );
+    }
+
+    @Test
+    void shouldNotCreateDefaultJavaToJavascriptConverterWhenCreationIsDisabled() {
+        // expect
+        contextRunner.withPropertyValues(REGISTRY_CONFIGURATION).withBean(LocalValidatorFactoryBean.class)
+            .withPropertyValues("nrich.registry.default-java-to-javascript-converter-enabled=false").run(context ->
+                assertThat(context).doesNotHaveBean(JavaToJavascriptTypeConverter.class)
+            );
     }
 
     @Test

--- a/nrich-registry/build.gradle
+++ b/nrich-registry/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 
   enversImplementation "org.hibernate:hibernate-envers"
 
+  implementation project(":nrich-javascript")
+
   implementation "org.apache.commons:commons-lang3"
 
   runtimeOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationService.java
@@ -18,16 +18,15 @@
 package net.croz.nrich.registry.configuration.service;
 
 import lombok.RequiredArgsConstructor;
+import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import net.croz.nrich.registry.api.configuration.model.RegistryEntityConfiguration;
 import net.croz.nrich.registry.api.configuration.model.RegistryGroupConfiguration;
-import net.croz.nrich.javascript.model.JavascriptType;
 import net.croz.nrich.registry.api.configuration.model.property.RegistryPropertyConfiguration;
 import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
 import net.croz.nrich.registry.api.core.model.RegistryOverrideConfiguration;
 import net.croz.nrich.registry.configuration.comparator.RegistryGroupConfigurationComparator;
 import net.croz.nrich.registry.configuration.comparator.RegistryPropertyComparator;
 import net.croz.nrich.registry.configuration.constants.RegistryConfigurationConstants;
-import net.croz.nrich.javascript.util.JavaToJavascriptTypeConversionUtil;
 import net.croz.nrich.registry.core.constants.RegistryCoreConstants;
 import net.croz.nrich.registry.core.constants.RegistryEnversConstants;
 import net.croz.nrich.registry.core.model.PropertyWithType;
@@ -44,6 +43,7 @@ import org.springframework.context.support.DefaultMessageSourceResolvable;
 import javax.persistence.metamodel.Attribute;
 import javax.persistence.metamodel.ManagedType;
 import javax.persistence.metamodel.SingularAttribute;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -67,6 +67,8 @@ public class DefaultRegistryConfigurationService implements RegistryConfiguratio
     private final RegistryHistoryConfigurationHolder registryHistoryConfiguration;
 
     private final Map<Class<?>, RegistryOverrideConfiguration> registryOverrideConfigurationMap;
+
+    private final JavaToJavascriptTypeConversionService javaToJavascriptTypeConversionService;
 
     @Cacheable("nrich.registryConfiguration.cache")
     @Override
@@ -204,8 +206,8 @@ public class DefaultRegistryConfigurationService implements RegistryConfiguratio
     private RegistryPropertyConfiguration resolveRegistryPropertyConfiguration(String entityTypePrefix, Class<?> attributeType, String attributeName, boolean isIdAttribute,
                                                                                boolean isSingularAssociation, Class<?> singularAssociationReferencedClass, boolean isReadOnly,
                                                                                boolean isSortable, boolean isSearchable) {
-        JavascriptType javascriptType = JavaToJavascriptTypeConversionUtil.fromJavaType(attributeType);
-        boolean isDecimal = JavaToJavascriptTypeConversionUtil.isDecimal(attributeType);
+        String javascriptType = javaToJavascriptTypeConversionService.convert(attributeType);
+        boolean isDecimal = isDecimal(attributeType);
 
         String attributeDisplayName = convertToDisplayValue(attributeName);
         String formLabel = formLabel(entityTypePrefix, attributeType, attributeName, attributeDisplayName);
@@ -295,4 +297,9 @@ public class DefaultRegistryConfigurationService implements RegistryConfiguratio
 
         return StringUtils.capitalize(String.join(RegistryCoreConstants.SPACE, attributeWordList));
     }
+
+    private boolean isDecimal(Class<?> type) {
+        return type.isAssignableFrom(BigDecimal.class) || type.isAssignableFrom(Float.class) || type.isAssignableFrom(Double.class);
+    }
+
 }

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/RegistryTestConfiguration.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/RegistryTestConfiguration.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter;
+import net.croz.nrich.javascript.service.DefaultJavaToJavascriptTypeConversionService;
+import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
 import net.croz.nrich.registry.api.core.model.RegistryConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryGroupDefinitionConfiguration;
@@ -211,13 +214,21 @@ public class RegistryTestConfiguration {
     }
 
     @Bean
-    public RegistryConfigurationService registryConfigurationService(MessageSource messageSource, RegistryConfigurationResolverService registryConfigurationResolverService) {
+    public JavaToJavascriptTypeConversionService javaToJavascriptTypeConversionService() {
+        return new DefaultJavaToJavascriptTypeConversionService(Collections.singletonList(new DefaultJavaToJavascriptTypeConverter()));
+    }
+
+    @Bean
+    public RegistryConfigurationService registryConfigurationService(MessageSource messageSource, RegistryConfigurationResolverService registryConfigurationResolverService,
+                                                                     JavaToJavascriptTypeConversionService javaToJavascriptTypeConversionService) {
         List<String> defaultReadOnlyPropertyList = Arrays.asList("id", "version");
         RegistryGroupDefinitionHolder registryGroupDefinitionHolder = registryConfigurationResolverService.resolveRegistryGroupDefinition();
         RegistryHistoryConfigurationHolder registryHistoryConfigurationHolder = registryConfigurationResolverService.resolveRegistryHistoryConfiguration();
         Map<Class<?>, RegistryOverrideConfiguration> registryOverrideConfigurationMap = registryConfigurationResolverService.resolveRegistryOverrideConfigurationMap();
 
-        return new DefaultRegistryConfigurationService(messageSource, defaultReadOnlyPropertyList, registryGroupDefinitionHolder, registryHistoryConfigurationHolder, registryOverrideConfigurationMap);
+        return new DefaultRegistryConfigurationService(
+            messageSource, defaultReadOnlyPropertyList, registryGroupDefinitionHolder, registryHistoryConfigurationHolder, registryOverrideConfigurationMap, javaToJavascriptTypeConversionService
+        );
     }
 
     @Bean

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationServiceTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationServiceTest.java
@@ -20,7 +20,6 @@ package net.croz.nrich.registry.configuration.service;
 import net.croz.nrich.registry.RegistryTestConfiguration;
 import net.croz.nrich.registry.api.configuration.model.RegistryEntityConfiguration;
 import net.croz.nrich.registry.api.configuration.model.RegistryGroupConfiguration;
-import net.croz.nrich.javascript.model.JavascriptType;
 import net.croz.nrich.registry.api.configuration.model.property.RegistryPropertyConfiguration;
 import net.croz.nrich.registry.configuration.stub.RegistryConfigurationTestEntity;
 import net.croz.nrich.registry.configuration.stub.RegistryConfigurationTestEntityWithAssociationAndEmbeddedId;
@@ -91,7 +90,7 @@ class DefaultRegistryConfigurationServiceTest {
         RegistryPropertyConfiguration nameConfiguration = registryEntityConfiguration.getPropertyConfigurationList().get(0);
 
         // then
-        assertThat(nameConfiguration.getJavascriptType()).isEqualTo(JavascriptType.STRING);
+        assertThat(nameConfiguration.getJavascriptType()).isEqualTo("string");
         assertThat(nameConfiguration.getOriginalType()).isEqualTo(String.class.getName());
         assertThat(nameConfiguration.isId()).isFalse();
         assertThat(nameConfiguration.isDecimal()).isFalse();
@@ -111,7 +110,7 @@ class DefaultRegistryConfigurationServiceTest {
         RegistryPropertyConfiguration nonEditablePropertyConfiguration = registryEntityConfiguration.getPropertyConfigurationList().get(2);
 
         // then
-        assertThat(nonEditablePropertyConfiguration.getJavascriptType()).isEqualTo(JavascriptType.STRING);
+        assertThat(nonEditablePropertyConfiguration.getJavascriptType()).isEqualTo("string");
         assertThat(nonEditablePropertyConfiguration.getOriginalType()).isEqualTo(String.class.getName());
         assertThat(nonEditablePropertyConfiguration.isId()).isFalse();
         assertThat(nameConfiguration.isDecimal()).isFalse();
@@ -162,7 +161,7 @@ class DefaultRegistryConfigurationServiceTest {
 
         // then
         assertThat(numberRegistryConfiguration.isDecimal()).isTrue();
-        assertThat(numberRegistryConfiguration.getJavascriptType()).isEqualTo(JavascriptType.NUMBER);
+        assertThat(numberRegistryConfiguration.getJavascriptType()).isEqualTo("number");
 
         // and when
         RegistryPropertyConfiguration manyToOnePropertyConfiguration = registryEntityConfiguration.getPropertyConfigurationList().get(2);

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ include(
   "nrich-jackson",
   "nrich-jackson-spring-boot-starter",
   "nrich-javascript",
+  "nrich-javascript-api",
   "nrich-logging-api",
   "nrich-logging",
   "nrich-logging-spring-boot-starter",


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.5.0
* Module:
project
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Added support for users to override Javascript type by implementing a JavaToJavascriptTypeConverter interface, changed Javascript type for enums to string.

### Details

Added support for users to override Javascript type by implementing a JavaToJavascriptTypeConverter interface, changed Javascript type for enums to string.

### Related issue

https://github.com/croz-ltd/nrich/issues/139

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
