### PR TITLE
Enable easier registration of search overrides in registry module

### DIFF
--- a/nrich-registry-spring-boot-starter/README.md
+++ b/nrich-registry-spring-boot-starter/README.md
@@ -72,6 +72,9 @@ nrich.registry:
 
 ```
 
+Overriding of default registry behaviour (i.e. in search configuration which operators are used for searching) is possible by defining a bean of
+type [RegistryOverrideConfigurationHolder](../nrich-registry-api/src/main/java/net/croz/nrich/registry/api/core/model/RegistryOverrideConfigurationHolder.java)
+
 ### Using the module
 
 This module is meant to be used through REST API and as such exposes multiple endpoints. For a detailed description of each endpoint see `nrich-registry` [README.MD](../nrich-registry/README.md).

--- a/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfiguration.java
+++ b/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfiguration.java
@@ -23,12 +23,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import net.croz.nrich.formconfiguration.api.customizer.FormConfigurationMappingCustomizer;
-import net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter;
 import net.croz.nrich.javascript.api.converter.JavaToJavascriptTypeConverter;
-import net.croz.nrich.javascript.service.DefaultJavaToJavascriptTypeConversionService;
 import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
+import net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter;
+import net.croz.nrich.javascript.service.DefaultJavaToJavascriptTypeConversionService;
 import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
 import net.croz.nrich.registry.api.core.model.RegistryOverrideConfiguration;
+import net.croz.nrich.registry.api.core.model.RegistryOverrideConfigurationHolder;
 import net.croz.nrich.registry.api.core.service.RegistryEntityFinderService;
 import net.croz.nrich.registry.api.data.interceptor.RegistryDataInterceptor;
 import net.croz.nrich.registry.api.data.service.RegistryDataService;
@@ -80,6 +81,7 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceContext;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -171,7 +173,20 @@ public class NrichRegistryAutoConfiguration {
 
     @ConditionalOnMissingBean
     @Bean
-    public RegistryConfigurationResolverService registryConfigurationResolverService(NrichRegistryProperties registryProperties) {
+    public RegistryConfigurationResolverService registryConfigurationResolverService(NrichRegistryProperties registryProperties,
+                                                                                     @Autowired(required = false) List<RegistryOverrideConfigurationHolder> registryOverrideConfigurationHolderList) {
+
+        List<RegistryOverrideConfigurationHolder> overrideConfigurationHolderList = registryProperties.getRegistryConfiguration().getOverrideConfigurationHolderList();
+
+        if (overrideConfigurationHolderList == null) {
+            overrideConfigurationHolderList = new ArrayList<>();
+        }
+        if (registryOverrideConfigurationHolderList != null) {
+            overrideConfigurationHolderList.addAll(registryOverrideConfigurationHolderList);
+        }
+
+        registryProperties.getRegistryConfiguration().setOverrideConfigurationHolderList(overrideConfigurationHolderList);
+
         return new DefaultRegistryConfigurationResolverService(entityManager, registryProperties.getRegistryConfiguration());
     }
 

--- a/nrich-registry-spring-boot-starter/src/test/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfigurationTest.java
+++ b/nrich-registry-spring-boot-starter/src/test/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfigurationTest.java
@@ -24,6 +24,7 @@ import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionServi
 import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
 import net.croz.nrich.registry.api.core.model.RegistryConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryGroupDefinitionConfiguration;
+import net.croz.nrich.registry.api.core.model.RegistryOverrideConfigurationHolder;
 import net.croz.nrich.registry.api.data.service.RegistryDataService;
 import net.croz.nrich.registry.api.history.service.RegistryHistoryService;
 import net.croz.nrich.registry.configuration.controller.RegistryConfigurationController;
@@ -195,6 +196,19 @@ class NrichRegistryAutoConfigurationTest {
             // then
             assertThat(result.getId()).isEqualTo("initial");
             assertThat(result.getName()).isEqualTo("name");
+        });
+    }
+
+    @Test
+    void shouldRegisterRegistryOverrideConfiguration() {
+        RegistryOverrideConfigurationHolder holder = RegistryOverrideConfigurationHolder.builder().build();
+
+        contextRunner.withPropertyValues(REGISTRY_CONFIGURATION).withBean(RegistryOverrideConfigurationHolder.class, () -> holder).run(context -> {
+            // when
+            NrichRegistryProperties registryProperties = context.getBean(NrichRegistryProperties.class);
+
+            // then
+            assertThat(registryProperties.getRegistryConfiguration().getOverrideConfigurationHolderList()).containsExactly(holder);
         });
     }
 }


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.7.0
* Module:
nrich-registry-spring-boot-starter

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Added support for overriding registry configuration by defining a bean of type `RegistryOverrideConfigurationHolder`.

### Details

Added support for overriding registry configuration by defining a bean of type `RegistryOverrideConfigurationHolder`.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
