### PR TITLE
Support mapping of ids on registry entities to support saving of asso…

### DIFF
--- a/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfiguration.java
+++ b/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfiguration.java
@@ -58,7 +58,6 @@ import net.croz.nrich.search.api.converter.StringToTypeConverter;
 import net.croz.nrich.search.converter.DefaultStringToEntityPropertyMapConverter;
 import net.croz.nrich.search.converter.DefaultStringToTypeConverter;
 import net.croz.nrich.springboot.condition.ConditionalOnPropertyNotEmpty;
-import org.modelmapper.Condition;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,23 +111,13 @@ public class NrichRegistryAutoConfiguration {
     @ConditionalOnMissingBean(name = "registryDataModelMapper")
     @Bean
     public ModelMapper registryDataModelMapper() {
-        ModelMapper modelMapper = new ModelMapper();
-        Condition<Object, Object> skipIds = context -> !context.getMapping().getLastDestinationProperty().getName().equals("id");
-
-        modelMapper.getConfiguration().setPropertyCondition(skipIds);
-        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-
-        return modelMapper;
+        return strictModelMapper();
     }
 
     @ConditionalOnMissingBean(name = "registryBaseModelMapper")
     @Bean
     public ModelMapper registryBaseModelMapper() {
-        ModelMapper modelMapper = new ModelMapper();
-
-        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-
-        return modelMapper;
+       return strictModelMapper();
     }
 
     @ConditionalOnMissingBean
@@ -294,5 +283,13 @@ public class NrichRegistryAutoConfiguration {
             .collect(Collectors.toList());
 
         return new RegistryDataFormConfigurationMappingCustomizer(registryClassList);
+    }
+
+    private ModelMapper strictModelMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+
+        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+
+        return modelMapper;
     }
 }

--- a/nrich-registry-spring-boot-starter/src/test/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfigurationTest.java
+++ b/nrich-registry-spring-boot-starter/src/test/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfigurationTest.java
@@ -33,12 +33,10 @@ import net.croz.nrich.registry.data.controller.RegistryDataController;
 import net.croz.nrich.registry.data.service.RegistryDataRequestConversionService;
 import net.croz.nrich.registry.history.controller.RegistryHistoryController;
 import net.croz.nrich.registry.security.interceptor.RegistryConfigurationUpdateInterceptor;
-import net.croz.nrich.registry.starter.configuration.stub.ModelMapperTestEntity;
 import net.croz.nrich.registry.starter.properties.NrichRegistryProperties;
 import net.croz.nrich.search.api.converter.StringToEntityPropertyMapConverter;
 import net.croz.nrich.search.api.converter.StringToTypeConverter;
 import org.junit.jupiter.api.Test;
-import org.modelmapper.ModelMapper;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
@@ -177,26 +175,6 @@ class NrichRegistryAutoConfigurationTest {
             .withPropertyValues("nrich.registry.default-java-to-javascript-converter-enabled=false").run(context ->
                 assertThat(context).doesNotHaveBean(JavaToJavascriptTypeConverter.class)
             );
-    }
-
-    @Test
-    void shouldSkipIdCopyInRegisteredModelMapperInstance() {
-        contextRunner.withPropertyValues(REGISTRY_CONFIGURATION).withBean(LocalValidatorFactoryBean.class).run(context -> {
-            // given
-            ModelMapper modelMapper = context.getBean("registryDataModelMapper", ModelMapper.class);
-            ModelMapperTestEntity modelMapperTestEntity = new ModelMapperTestEntity();
-
-            modelMapperTestEntity.setName("name");
-            modelMapperTestEntity.setId("id");
-
-            // when
-            ModelMapperTestEntity result = new ModelMapperTestEntity();
-            modelMapper.map(modelMapperTestEntity, result);
-
-            // then
-            assertThat(result.getId()).isEqualTo("initial");
-            assertThat(result.getName()).isEqualTo("name");
-        });
     }
 
     @Test

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/data/service/DefaultRegistryDataService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/data/service/DefaultRegistryDataService.java
@@ -17,6 +17,7 @@
 
 package net.croz.nrich.registry.data.service;
 
+import lombok.SneakyThrows;
 import net.croz.nrich.registry.api.core.service.RegistryEntityFinderService;
 import net.croz.nrich.registry.api.data.interceptor.RegistryDataInterceptor;
 import net.croz.nrich.registry.api.data.request.ListBulkRegistryRequest;
@@ -37,10 +38,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ReflectionUtils;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaQuery;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -121,9 +124,14 @@ public class DefaultRegistryDataService implements RegistryDataService {
         if (wrapper.isIdClassIdentifier() || wrapper.isEmbeddedIdentifier()) {
             entityManager.remove(instance);
             instance = resolveEntityInstance(registryDataConfiguration.getRegistryType(), entityData);
-        }
 
-        modelMapper.map(entityData, instance);
+            modelMapper.map(entityData, instance);
+        }
+        else {
+            setIdFieldToOriginalValue(wrapper, entityData, id);
+
+            modelMapper.map(entityData, instance);
+        }
 
         return entityManager.merge(instance);
     }
@@ -200,5 +208,23 @@ public class DefaultRegistryDataService implements RegistryDataService {
         }
 
         return BeanUtils.instantiateClass(type);
+    }
+
+    // in case users submit a null id value inside entity data it should be reset
+    @SneakyThrows
+    private void setIdFieldToOriginalValue(ManagedTypeWrapper managedTypeWrapper, Object instance, Object id) {
+        Field field = ReflectionUtils.findField(instance.getClass(), managedTypeWrapper.getIdAttributeName());
+
+        if (field == null) {
+            return;
+        }
+
+        field.setAccessible(true); // NOSONAR
+
+        if (id.equals(field.get(instance))) {
+            return;
+        }
+
+        field.set(instance, id); // NOSONAR
     }
 }

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/RegistryTestConfiguration.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/RegistryTestConfiguration.java
@@ -22,9 +22,9 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
+import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter;
 import net.croz.nrich.javascript.service.DefaultJavaToJavascriptTypeConversionService;
-import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
 import net.croz.nrich.registry.api.core.model.RegistryConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryGroupDefinitionConfiguration;
@@ -61,7 +61,6 @@ import net.croz.nrich.search.api.model.operator.DefaultSearchOperator;
 import net.croz.nrich.search.api.model.operator.SearchOperatorOverride;
 import net.croz.nrich.search.converter.DefaultStringToEntityPropertyMapConverter;
 import net.croz.nrich.search.converter.DefaultStringToTypeConverter;
-import org.modelmapper.Condition;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,22 +126,12 @@ public class RegistryTestConfiguration {
 
     @Bean
     public ModelMapper registryDataModelMapper() {
-        ModelMapper modelMapper = new ModelMapper();
-        Condition<Object, Object> skipIds = context -> !context.getMapping().getLastDestinationProperty().getName().equals("id");
-
-        modelMapper.getConfiguration().setPropertyCondition(skipIds);
-        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-
-        return modelMapper;
+        return strictModelMapper();
     }
 
     @Bean
     public ModelMapper registryBaseModelMapper() {
-        ModelMapper modelMapper = new ModelMapper();
-
-        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-
-        return modelMapper;
+        return strictModelMapper();
     }
 
     @Bean
@@ -332,5 +321,13 @@ public class RegistryTestConfiguration {
             .type(RegistryTestEntityWithOverriddenSearchConfiguration.class).overrideSearchConfiguration(searchConfiguration).build();
 
         return Arrays.asList(interceptorTestEntityConfigurationHolder, InterceptorTestNonEntityNonModifiableConfigurationHolder, searchConfigurationHolder, configurationEntityConfigurationHolder);
+    }
+
+    private ModelMapper strictModelMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+
+        modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+
+        return modelMapper;
     }
 }

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/service/DefaultRegistryDataServiceTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/service/DefaultRegistryDataServiceTest.java
@@ -164,7 +164,28 @@ class DefaultRegistryDataServiceTest {
     void shouldUpdateRegistryEntity() {
         // given
         RegistryTestEntity registryTestEntity = createRegistryTestEntity(entityManager);
-        UpdateRegistryTestEntityRequest request = createUpdateRegistryTestEntityRequest();
+        UpdateRegistryTestEntityRequest request = createUpdateRegistryTestEntityRequest(null);
+
+        // when
+        RegistryTestEntity updatedEntity = registryDataService.update(RegistryTestEntity.class.getName(), registryTestEntity.getId(), request);
+
+        // then
+        assertThat(updatedEntity).isNotNull();
+
+        // and when
+        flushEntityManager(entityManager);
+        RegistryTestEntity loaded = entityManager.find(RegistryTestEntity.class, registryTestEntity.getId());
+
+        // then
+        assertThat(loaded.getAge()).isEqualTo(51);
+        assertThat(loaded.getName()).isEqualTo("name 2");
+    }
+
+    @Test
+    void shouldUpdateEntityAndSkipSettingIdToOriginalValue() {
+        // given
+        RegistryTestEntity registryTestEntity = createRegistryTestEntity(entityManager);
+        UpdateRegistryTestEntityRequest request = createUpdateRegistryTestEntityRequest(111L);
 
         // when
         RegistryTestEntity updatedEntity = registryDataService.update(RegistryTestEntity.class.getName(), registryTestEntity.getId(), request);
@@ -185,7 +206,7 @@ class DefaultRegistryDataServiceTest {
     void shouldUpdateRegistryEntityWithoutAssociations() {
         // given
         RegistryTestEntityWithoutAssociation registryTestEntity = createRegistryTestEntityWithoutAssociation(entityManager);
-        UpdateRegistryTestEntityRequest request = createUpdateRegistryTestEntityRequest();
+        UpdateRegistryTestEntityRequest request = createUpdateRegistryTestEntityRequest(registryTestEntity.getId());
 
         // when
         RegistryTestEntityWithoutAssociation updatedEntity = registryDataService.update(RegistryTestEntityWithoutAssociation.class.getName(), registryTestEntity.getId(), request);
@@ -338,5 +359,26 @@ class DefaultRegistryDataServiceTest {
 
         // then
         assertThat(loaded).isNull();
+    }
+
+    @Test
+    void shouldCreateRegistryEntityWithAssociationFromRequestClass() {
+        // given
+        RegistryTestEntity registryTestEntity = createRegistryTestEntity(entityManager);
+
+        // when
+        RegistryTestEntity createdTestEntity = registryDataService.create(RegistryTestEntity.class.getName(), createRegistryTestEntityRequest("name 1", registryTestEntity.getId()));
+
+        // then
+        assertThat(createdTestEntity).isNotNull();
+
+        // and when
+        flushEntityManager(entityManager);
+        RegistryTestEntity loaded = entityManager.find(RegistryTestEntity.class, createdTestEntity.getId());
+
+        // then
+        assertThat(loaded.getAge()).isEqualTo(50);
+        assertThat(loaded.getName()).isEqualTo("name 1");
+        assertThat(loaded.getParent()).isNotNull();
     }
 }

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/stub/request/CreateEntityRequest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/stub/request/CreateEntityRequest.java
@@ -15,20 +15,15 @@
  *
  */
 
-package net.croz.nrich.registry.data.stub;
+package net.croz.nrich.registry.data.stub.request;
 
 import lombok.Getter;
 import lombok.Setter;
-import net.croz.nrich.registry.data.stub.request.CreateEntityRequest;
 
 @Setter
 @Getter
-public class CreateRegistryTestEntityRequest {
+public class CreateEntityRequest {
 
-    private String name;
-
-    private Integer age;
-
-    private CreateEntityRequest parent;
+    private Long id;
 
 }

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataGeneratingUtil.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataGeneratingUtil.java
@@ -38,6 +38,7 @@ import net.croz.nrich.registry.data.stub.RegistryTestEntityWithOverriddenSearchC
 import net.croz.nrich.registry.data.stub.RegistryTestEntityWithoutAssociation;
 import net.croz.nrich.registry.data.stub.RegistryTestGroupType;
 import net.croz.nrich.registry.data.stub.UpdateRegistryTestEntityRequest;
+import net.croz.nrich.registry.data.stub.request.CreateEntityRequest;
 
 import javax.persistence.EntityManager;
 import java.util.Arrays;
@@ -288,6 +289,18 @@ public final class RegistryDataGeneratingUtil {
         return idMap;
     }
 
+    public static CreateRegistryTestEntityRequest createRegistryTestEntityRequest(String name, Long parentId) {
+        CreateEntityRequest parent = new CreateEntityRequest();
+
+        parent.setId(parentId);
+
+        CreateRegistryTestEntityRequest request = createRegistryTestEntityRequest(name);
+
+        request.setParent(parent);
+
+        return request;
+    }
+
     public static CreateRegistryTestEntityRequest createRegistryTestEntityRequest(String name) {
         CreateRegistryTestEntityRequest request = new CreateRegistryTestEntityRequest();
 
@@ -297,10 +310,10 @@ public final class RegistryDataGeneratingUtil {
         return request;
     }
 
-    public static UpdateRegistryTestEntityRequest createUpdateRegistryTestEntityRequest() {
+    public static UpdateRegistryTestEntityRequest createUpdateRegistryTestEntityRequest(Long id) {
         UpdateRegistryTestEntityRequest request = new UpdateRegistryTestEntityRequest();
 
-        request.setId(100L);
+        request.setId(id);
         request.setName("name 2");
         request.setAge(51);
 


### PR DESCRIPTION
…ciations with custom request classes

<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.7.0
* Module:
nrich-registry

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add support for mapping of ids when saving and updating registry entity by using a custom Request class (i.e. CountryCreateRequest for Country entity).

### Details

Add support for mapping of ids when saving and updating registry entity by using a custom Request class (i.e. CountryCreateRequest for Country entity).

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
