### PR TITLE
Fix IllegalArgumentException when Jackson doesn't have DeserializationFeature.USE_LONG_FOR_INTS enabled

### DIFF
--- a/nrich-registry/src/main/java/net/croz/nrich/registry/data/service/DefaultRegistryDataService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/data/service/DefaultRegistryDataService.java
@@ -17,7 +17,6 @@
 
 package net.croz.nrich.registry.data.service;
 
-import lombok.SneakyThrows;
 import net.croz.nrich.registry.api.core.service.RegistryEntityFinderService;
 import net.croz.nrich.registry.api.data.interceptor.RegistryDataInterceptor;
 import net.croz.nrich.registry.api.data.request.ListBulkRegistryRequest;
@@ -38,12 +37,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.ReflectionUtils;
 
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaQuery;
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -210,21 +207,10 @@ public class DefaultRegistryDataService implements RegistryDataService {
         return BeanUtils.instantiateClass(type);
     }
 
-    // in case users submit a null id value inside entity data it should be reset
-    @SneakyThrows
-    private void setIdFieldToOriginalValue(ManagedTypeWrapper managedTypeWrapper, Object instance, Object id) {
-        Field field = ReflectionUtils.findField(instance.getClass(), managedTypeWrapper.getIdAttributeName());
+    // in case users submit a null id value inside entity data it should be reset, this seems to be the simplest way of doing that
+    private void setIdFieldToOriginalValue(ManagedTypeWrapper managedTypeWrapper, Object entityData, Object id) {
+        Map<String, Object> idValueMap = Collections.singletonMap(managedTypeWrapper.getIdAttributeName(), id);
 
-        if (field == null) {
-            return;
-        }
-
-        field.setAccessible(true); // NOSONAR
-
-        if (id.equals(field.get(instance))) {
-            return;
-        }
-
-        field.set(instance, id); // NOSONAR
+        modelMapper.map(idValueMap, entityData);
     }
 }

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/controller/RegistryDataControllerTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/controller/RegistryDataControllerTest.java
@@ -45,6 +45,7 @@ import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.c
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createRegistryTestEntityWithParent;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createUpdateEmbeddedUserGroupRequest;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.updateRegistryRequest;
+import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.updateRegistryRequestWithId;
 import static net.croz.nrich.registry.testutil.PersistenceTestUtil.executeInTransaction;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -147,6 +148,21 @@ class RegistryDataControllerTest extends BaseControllerTest {
         // then
         result.andExpect(status().isOk())
             .andExpect(jsonPath("$.name").value(entityName));
+    }
+
+    @Test
+    void shouldUpdateRegistryEntityWithIdSentInEntityData() throws Exception {
+        // given
+        RegistryTestEntity registryTestEntity = executeInTransaction(platformTransactionManager, () -> createRegistryTestEntity(entityManager));
+
+        String requestUrl = fullUrl("update");
+        UpdateRegistryRequest request = updateRegistryRequestWithId(objectMapper, REGISTRY_TYPE_NAME, registryTestEntity.getId());
+
+        // when
+        ResultActions result = performPostRequest(requestUrl, request);
+
+        // then
+        result.andExpect(status().isOk());
     }
 
     @Test

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/stub/RegistryTestEntityUpdateRequest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/stub/RegistryTestEntityUpdateRequest.java
@@ -26,6 +26,8 @@ import javax.validation.constraints.NotNull;
 @Getter
 public class RegistryTestEntityUpdateRequest {
 
+    private Long id;
+
     @NotNull
     private String name;
 

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataGeneratingUtil.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataGeneratingUtil.java
@@ -201,6 +201,17 @@ public final class RegistryDataGeneratingUtil {
         return request;
     }
 
+    @SneakyThrows
+    public static UpdateRegistryRequest updateRegistryRequestWithId(ObjectMapper objectMapper, String classFullName, Long id) {
+        UpdateRegistryRequest request = new UpdateRegistryRequest();
+
+        request.setClassFullName(classFullName);
+        request.setId(id);
+        request.setJsonEntityData(objectMapper.writeValueAsString(createUpdateRegistryTestEntityRequest(id)));
+
+        return request;
+    }
+
     public static RegistryTestEmbeddedUserGroup createRegistryTestEmbeddedUserGroup(EntityManager entityManager) {
         RegistryTestEmbeddedUser user = createRegistryTestEmbeddedUser(entityManager);
         RegistryTestEmbeddedGroup group = createRegistryTestEmbeddedGroup(entityManager);


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
1.8.0
* Module:
nrich-registry

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Simplify resetting of id property on entity data in nrich-registry update method and fix IllegalArgumentException when jackson doesn't have DeserializationFeature.USE_LONG_FOR_INTS enabled

### Details

Simplify resetting of id property on entity data in nrich-registry update method and fix IllegalArgumentException when jackson doesn't have DeserializationFeature.USE_LONG_FOR_INTS enabled

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~`
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
