### PR TITLE
Support usage of Groovy closure in @NotNullWhen and @NullWhen constraints

### DIFF
--- a/nrich-validation/README.md
+++ b/nrich-validation/README.md
@@ -111,6 +111,18 @@ public class CreatePersonRequest {
 
 will validate that firstName is not null when lastName is not null (effectively requiring both properties to be null or both properties to be empty).
 
+If Groovy is used, condition can be written as closure.
+
+```groovy
+@NotNullWhen(property = "firstName", condition = { request -> request.lastName != null })
+class CreatePersonRequest {
+
+    String firstName
+
+    String lastName
+}
+```
+
 #### NullWhen
 
 Validates that a property is null when a condition is satisfied i.e:
@@ -140,6 +152,20 @@ public class CreateBusinessEntityRequest {
 ```
 
 will validate that either companyName is filled or firstName or lastName are filled.
+
+If Groovy is used, condition can be written as closure.
+
+```groovy
+@NullWHen(property = "companyName", condition = { request -> request.fistName != null || request.lastName != null })
+class CreateBusinessEntityRequest {
+
+    String companyName
+
+    String fistName
+
+    String lastName
+}
+```
 
 #### ValidFile
 

--- a/nrich-validation/build.gradle
+++ b/nrich-validation/build.gradle
@@ -1,5 +1,7 @@
 description = "Provides additional Bean Validation constraints"
 
+apply plugin: "groovy"
+
 dependencies {
   api project(":nrich-validation-api")
 
@@ -22,6 +24,7 @@ dependencies {
   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
   testImplementation "io.projectreactor:reactor-core"
+  testImplementation "org.apache.groovy:groovy"
   testImplementation "org.assertj:assertj-core"
   testImplementation "org.junit.jupiter:junit-jupiter-api"
   testImplementation "org.junit.jupiter:junit-jupiter-params"

--- a/nrich-validation/src/main/java/net/croz/nrich/validation/constraint/util/GroovyUtil.java
+++ b/nrich-validation/src/main/java/net/croz/nrich/validation/constraint/util/GroovyUtil.java
@@ -1,0 +1,18 @@
+package net.croz.nrich.validation.constraint.util;
+
+import org.springframework.util.ClassUtils;
+
+import java.util.regex.Pattern;
+
+public final class GroovyUtil {
+
+    private static final Pattern GROOVY_CLOSURE_PATTERN = Pattern.compile(".*\\$_.*closure.*");
+
+    public static boolean isGroovyPresent() {
+        return ClassUtils.isPresent("groovy.lang.MetaClass", null);
+    }
+
+    public static boolean isGroovyClosure(Class<?> type) {
+        return GROOVY_CLOSURE_PATTERN.matcher(type.getName()).matches();
+    }
+}

--- a/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/stub/NotNullWhenWithGroovyClosureTestRequest.groovy
+++ b/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/stub/NotNullWhenWithGroovyClosureTestRequest.groovy
@@ -1,0 +1,11 @@
+package net.croz.nrich.validation.constraint.stub
+
+import net.croz.nrich.validation.api.constraint.NotNullWhen
+
+@NotNullWhen(property = "property", condition = { notNullWhenTestRequest -> "not null" == notNullWhenTestRequest.differentProperty })
+class NotNullWhenWithGroovyClosureTestRequest {
+
+  String property
+
+  String differentProperty
+}

--- a/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/stub/NullWhenWithGroovyClosureTestRequest.groovy
+++ b/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/stub/NullWhenWithGroovyClosureTestRequest.groovy
@@ -1,0 +1,11 @@
+package net.croz.nrich.validation.constraint.stub
+
+import net.croz.nrich.validation.api.constraint.NullWhen
+
+@NullWhen(property = "property", condition = { nullWhenTestRequest -> "not null" == nullWhenTestRequest.differentProperty })
+class NullWhenWithGroovyClosureTestRequest {
+
+  String property
+
+  String differentProperty
+}

--- a/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/util/GroovyUtilTest.groovy
+++ b/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/util/GroovyUtilTest.groovy
@@ -1,0 +1,51 @@
+package net.croz.nrich.validation.constraint.util
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.MockedStatic
+import org.springframework.util.ClassUtils
+
+import java.util.stream.Stream
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.mockito.Mockito.mockStatic
+
+class GroovyUtilTest {
+
+  @CsvSource(["true,true", "false,false"])
+  @ParameterizedTest
+  void shouldCheckIfGroovyIsPresent(boolean isMetaClassPresent, boolean expectedResult) {
+    // given
+    MockedStatic<ClassUtils> classUtilsMock = mockStatic(ClassUtils)
+    classUtilsMock.when(() -> ClassUtils.isPresent("groovy.lang.MetaClass", null)).thenReturn(isMetaClassPresent)
+
+    // when
+    boolean result = GroovyUtil.isGroovyPresent()
+
+    // then
+    assertThat(result).isEqualTo(expectedResult)
+
+    // cleanup
+    classUtilsMock.close()
+  }
+
+
+  @MethodSource("shouldCheckIfGivenClassIsGroovyClosureMethodSource")
+  @ParameterizedTest
+  void shouldCheckIfGivenClassIsGroovyClosure(Class<?> type, boolean expectedResult) {
+    // when
+    boolean result = GroovyUtil.isGroovyClosure(type)
+
+    // then
+    assertThat(result).isEqualTo(expectedResult)
+  }
+
+  private static Stream<Arguments> shouldCheckIfGivenClassIsGroovyClosureMethodSource() {
+    Stream.of(
+        Arguments.arguments({ String inputString -> inputString.toUpperCase() }.class, true),
+        Arguments.arguments(String, false)
+    )
+  }
+}

--- a/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/validator/NotNullWhenValidatorWithGroovyClosureTest.groovy
+++ b/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/validator/NotNullWhenValidatorWithGroovyClosureTest.groovy
@@ -1,0 +1,75 @@
+package net.croz.nrich.validation.constraint.validator
+
+import net.croz.nrich.validation.ValidationTestConfiguration
+import net.croz.nrich.validation.constraint.stub.NotNullWhenWithGroovyClosureTestRequest
+import net.croz.nrich.validation.constraint.util.GroovyUtil
+import org.junit.jupiter.api.Test
+import org.mockito.MockedStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+
+import jakarta.validation.ConstraintViolation
+import jakarta.validation.Validator
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.assertj.core.api.Assertions.catchThrowable
+import static org.mockito.Mockito.mockStatic
+
+@SpringJUnitConfig(ValidationTestConfiguration)
+class NotNullWhenValidatorWithGroovyClosureTest {
+
+  @Autowired
+  private Validator validator
+
+  @Test
+  void shouldNotReportErrorWhenPropertyIsNullAndConditionIsFalse() {
+    // given
+    NotNullWhenWithGroovyClosureTestRequest request = new NotNullWhenWithGroovyClosureTestRequest(property: null, differentProperty: "different property")
+
+    // when
+    Set<ConstraintViolation<NotNullWhenWithGroovyClosureTestRequest>> constraintViolationList = validator.validate(request)
+
+    // then
+    assertThat(constraintViolationList).isEmpty()
+  }
+
+  @Test
+  void shouldNotReportErrorWhenPropertyIsNotNullAndConditionIsTrue() {
+    // given
+    NotNullWhenWithGroovyClosureTestRequest request = new NotNullWhenWithGroovyClosureTestRequest(property: "value", differentProperty: "not null")
+
+    // when
+    Set<ConstraintViolation<NotNullWhenWithGroovyClosureTestRequest>> constraintViolationList = validator.validate(request)
+
+    // then
+    assertThat(constraintViolationList).isEmpty()
+  }
+
+  @Test
+  void shouldReportErrorWhenPropertyIsNullAndConditionIsTrue() {
+    // given
+    NotNullWhenWithGroovyClosureTestRequest request = new NotNullWhenWithGroovyClosureTestRequest(property: null, differentProperty: "not null")
+
+    // when
+    Set<ConstraintViolation<NotNullWhenWithGroovyClosureTestRequest>> constraintViolationList = validator.validate(request)
+
+    // then
+    assertThat(constraintViolationList).isNotEmpty()
+  }
+
+  @Test
+  void shouldThrowExceptionIfGroovyIsNotPresentWhenConditionIsGroovyClosure() {
+    // given
+    MockedStatic<GroovyUtil> groovyUtilMock = mockStatic(GroovyUtil)
+    groovyUtilMock.when(GroovyUtil::isGroovyPresent).thenReturn(false)
+
+    // when
+    Throwable thrown = catchThrowable(() -> validator.validate(new NotNullWhenWithGroovyClosureTestRequest()))
+
+    // then
+    assertThat(thrown).isNotNull()
+
+    // cleanup
+    groovyUtilMock.close()
+  }
+}

--- a/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/validator/NullWhenValidatorWithGroovyClosureTest.groovy
+++ b/nrich-validation/src/test/groovy/net/croz/nrich/validation/constraint/validator/NullWhenValidatorWithGroovyClosureTest.groovy
@@ -1,0 +1,75 @@
+package net.croz.nrich.validation.constraint.validator
+
+import net.croz.nrich.validation.ValidationTestConfiguration
+import net.croz.nrich.validation.constraint.stub.NullWhenWithGroovyClosureTestRequest
+import net.croz.nrich.validation.constraint.util.GroovyUtil
+import org.junit.jupiter.api.Test
+import org.mockito.MockedStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+
+import jakarta.validation.ConstraintViolation
+import jakarta.validation.Validator
+
+import static org.assertj.core.api.Assertions.assertThat
+import static org.assertj.core.api.Assertions.catchThrowable
+import static org.mockito.Mockito.mockStatic
+
+@SpringJUnitConfig(ValidationTestConfiguration)
+class NullWhenValidatorWithGroovyClosureTest {
+
+  @Autowired
+  private Validator validator
+
+  @Test
+  void shouldNotReportErrorWhenPropertyIsNotNullAndConditionIsFalse() {
+    // given
+    NullWhenWithGroovyClosureTestRequest request = new NullWhenWithGroovyClosureTestRequest(property: "value of property", differentProperty: "different property")
+
+    // when
+    Set<ConstraintViolation<NullWhenWithGroovyClosureTestRequest>> constraintViolationList = validator.validate(request)
+
+    // then
+    assertThat(constraintViolationList).isEmpty()
+  }
+
+  @Test
+  void shouldNotReportErrorWhenPropertyIsNullAndConditionIsTrue() {
+    // given
+    NullWhenWithGroovyClosureTestRequest request = new NullWhenWithGroovyClosureTestRequest(property: null, differentProperty: "not null")
+
+    // when
+    Set<ConstraintViolation<NullWhenWithGroovyClosureTestRequest>> constraintViolationList = validator.validate(request)
+
+    // then
+    assertThat(constraintViolationList).isEmpty()
+  }
+
+  @Test
+  void shouldReportErrorWhenPropertyIsNotNullAndConditionIsTrue() {
+    // given
+    NullWhenWithGroovyClosureTestRequest request = new NullWhenWithGroovyClosureTestRequest(property: "value", differentProperty: "not null")
+
+    // when
+    Set<ConstraintViolation<NullWhenWithGroovyClosureTestRequest>> constraintViolationList = validator.validate(request)
+
+    // then
+    assertThat(constraintViolationList).isNotEmpty()
+  }
+
+  @Test
+  void shouldThrowExceptionIfGroovyIsNotPresentWhenConditionIsGroovyClosure() {
+    // given
+    MockedStatic<GroovyUtil> groovyUtilMock = mockStatic(GroovyUtil)
+    groovyUtilMock.when(GroovyUtil::isGroovyPresent).thenReturn(false)
+
+    // when
+    Throwable thrown = catchThrowable(() -> validator.validate(new NullWhenWithGroovyClosureTestRequest()))
+
+    // then
+    assertThat(thrown).isNotNull()
+
+    // cleanup
+    groovyUtilMock.close()
+  }
+}


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version: 2.0.0
  <!-- released version or snapshot version -->
* Module: nrich-validation-api, nrich-validation
  <!-- Please, include name(s) of relevant nrich's module(s). If not related to any specific module, specify "project" instead. -->

## Description

### Summary

Support usage of Groovy closure in `@NotNullWhen` and `@NullWhen` constraints.

### Details

Condition for the `@NotNullWhen` and `@NullWhen` constraints can now be expressed with Groovy closure.

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Enhancement (non-breaking change which enhances existing functionality)
- Docs change

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
