### PR TITLE
Relax access modifiers for Slf4jLoggingService

### DIFF
--- a/nrich-logging/src/main/java/net/croz/nrich/logging/service/Slf4jLoggingService.java
+++ b/nrich-logging/src/main/java/net/croz/nrich/logging/service/Slf4jLoggingService.java
@@ -106,6 +106,22 @@ public class Slf4jLoggingService implements LoggingService {
         return LoggingVerbosityLevel.FULL;
     }
 
+    protected String fetchClassNameForException(Exception exception) {
+        if (exception == null) {
+            return "";
+        }
+
+        return exception.getClass().getName();
+    }
+
+    protected String fetchMessageForException(Exception exception) {
+        if (exception == null) {
+            return "";
+        }
+
+        return exception.getMessage();
+    }
+
     private LoggingLevel fetchConfiguredLoggingLevelForException(String exceptionClassName) {
         MessageSourceAccessor messageSourceAccessor = new MessageSourceAccessor(messageSource);
 
@@ -120,22 +136,6 @@ public class Slf4jLoggingService implements LoggingService {
         }
 
         return LoggingLevel.ERROR;
-    }
-
-    private String fetchClassNameForException(Exception exception) {
-        if (exception == null) {
-            return "";
-        }
-
-        return exception.getClass().getName();
-    }
-
-    private String fetchMessageForException(Exception exception) {
-        if (exception == null) {
-            return "";
-        }
-
-        return exception.getMessage();
     }
 
     private String prepareExceptionAuxiliaryDataMessage(Map<String, ?> exceptionAuxiliaryData, String separator) {


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.0.0
* Module:
nrich-logging

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Relax access modifiers for Slf4jLoggingService to make it possible for clients to override methods

### Details

Relax access modifiers for Slf4jLoggingService to make it possible for clients to override methods

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~`
- ~~I have updated the documentation accordingly~~
-  ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
