### PR TITLE
Add support for resolving domain class from repository method to make…

### DIFF
--- a/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/repository/SearchExecutor.java
+++ b/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/repository/SearchExecutor.java
@@ -101,4 +101,10 @@ public interface SearchExecutor<T> {
      */
     <R, P> boolean exists(R request, SearchConfiguration<T, P, R> searchConfiguration);
 
+    /**
+     * Returns repository domain class.
+     *
+     * @return repository domain class
+     */
+    Class<T> getDomainClass();
 }

--- a/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/repository/StringSearchExecutor.java
+++ b/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/repository/StringSearchExecutor.java
@@ -97,4 +97,10 @@ public interface StringSearchExecutor<T> {
      */
     <P> boolean exists(String searchTerm, List<String> propertyToSearchList, SearchConfiguration<T, P, Map<String, Object>> searchConfiguration);
 
+    /**
+     * Returns repository domain class.
+     *
+     * @return repository domain class
+     */
+    Class<T> getDomainClass();
 }

--- a/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaSearchExecutor.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaSearchExecutor.java
@@ -42,11 +42,14 @@ public class JpaSearchExecutor<T> implements SearchExecutor<T> {
 
     private final EntityManager entityManager;
 
+    private final Class<T> domainClass;
+
     private final JpaQueryBuilder<T> queryBuilder;
 
     public JpaSearchExecutor(EntityManager entityManager, JpaEntityInformation<T, ?> entityInformation) {
         this.entityManager = entityManager;
-        this.queryBuilder = new JpaQueryBuilder<>(entityManager, entityInformation.getJavaType());
+        domainClass = entityInformation.getJavaType();
+        queryBuilder = new JpaQueryBuilder<>(entityManager, entityInformation.getJavaType());
     }
 
     @Override
@@ -99,6 +102,11 @@ public class JpaSearchExecutor<T> implements SearchExecutor<T> {
         CriteriaQuery<Integer>  query = queryBuilder.buildExistsQuery(request, searchConfiguration);
 
         return entityManager.createQuery(query).setMaxResults(1).getResultList().size() == 1;
+    }
+
+    @Override
+    public Class<T> getDomainClass() {
+        return domainClass;
     }
 
     private <R, P> long executeCountQuery(R request, SearchConfiguration<T, P, R> searchConfiguration) {

--- a/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaStringSearchExecutor.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaStringSearchExecutor.java
@@ -46,6 +46,8 @@ public class JpaStringSearchExecutor<T> implements StringSearchExecutor<T> {
 
     private final EntityManager entityManager;
 
+    private final Class<T> domainClass;
+
     private final JpaQueryBuilder<T> queryBuilder;
 
     private final ManagedType<?> managedType;
@@ -53,8 +55,9 @@ public class JpaStringSearchExecutor<T> implements StringSearchExecutor<T> {
     public JpaStringSearchExecutor(StringToEntityPropertyMapConverter stringToEntityPropertyMapConverter, EntityManager entityManager, JpaEntityInformation<T, ?> jpaEntityInformation) {
         this.stringToEntityPropertyMapConverter = stringToEntityPropertyMapConverter;
         this.entityManager = entityManager;
-        this.queryBuilder = new JpaQueryBuilder<>(entityManager, jpaEntityInformation.getJavaType());
-        this.managedType = jpaEntityInformation.getRequiredIdAttribute().getDeclaringType();
+        domainClass = jpaEntityInformation.getJavaType();
+        queryBuilder = new JpaQueryBuilder<>(entityManager, jpaEntityInformation.getJavaType());
+        managedType = jpaEntityInformation.getRequiredIdAttribute().getDeclaringType();
     }
 
     @Override
@@ -119,6 +122,11 @@ public class JpaStringSearchExecutor<T> implements StringSearchExecutor<T> {
         CriteriaQuery<Integer> query = queryBuilder.buildExistsQuery(searchMap, searchConfiguration);
 
         return entityManager.createQuery(query).setMaxResults(1).getResultList().size() == 1;
+    }
+
+    @Override
+    public Class<T> getDomainClass() {
+        return domainClass;
     }
 
     private Map<String, Object> convertToMap(String searchTerm, List<String> propertyToSearchList, SearchConfiguration<T, ?, Map<String, Object>> searchConfiguration) {

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaSearchExecutorTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaSearchExecutorTest.java
@@ -262,4 +262,13 @@ class JpaSearchExecutorTest {
         // then
         assertThat(result).isFalse();
     }
+
+    @Test
+    void shouldReturnDomainClass() {
+        // when
+        Class<?> result = testEntitySearchRepository.getDomainClass();
+
+        // then
+        assertThat(result).isEqualTo(TestEntity.class);
+    }
 }

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaStringSearchExecutorTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaStringSearchExecutorTest.java
@@ -172,4 +172,13 @@ class JpaStringSearchExecutorTest {
         // then
         assertThat(result).isEqualTo(3);
     }
+
+    @Test
+    void shouldReturnDomainClass() {
+        // when
+        Class<?> result = testEntityStringSearchRepository.getDomainClass();
+
+        // then
+        assertThat(result).isEqualTo(TestStringSearchEntity.class);
+    }
 }


### PR DESCRIPTION
… AOP on repositories easier to work with

<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.1.1
* Module:
nrich-search

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add support for resolving domain class from repository method to make AOP on repositories easier to work wit

### Details

Add support for resolving domain class from repository method to make AOP on repositories easier to work wit

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
