### PR TITLE
Add support for resolving enum description from message source in excel

### DIFF
--- a/nrich-excel-spring-boot-starter/src/main/java/net/croz/nrich/excel/starter/configuration/NrichExcelAutoConfiguration.java
+++ b/nrich-excel-spring-boot-starter/src/main/java/net/croz/nrich/excel/starter/configuration/NrichExcelAutoConfiguration.java
@@ -29,6 +29,7 @@ import net.croz.nrich.excel.util.TypeDataFormatUtil;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ResourceLoader;
@@ -41,8 +42,8 @@ public class NrichExcelAutoConfiguration {
 
     @ConditionalOnProperty(name = "nrich.excel.default-converter-enabled", havingValue = "true", matchIfMissing = true)
     @Bean
-    public CellValueConverter defaultCellValueConverter() {
-        return new DefaultCellValueConverter();
+    public CellValueConverter defaultCellValueConverter(MessageSource messageSource) {
+        return new DefaultCellValueConverter(messageSource);
     }
 
     @ConditionalOnMissingBean

--- a/nrich-excel/README.md
+++ b/nrich-excel/README.md
@@ -17,8 +17,8 @@ To be able to use this module following configuration is required:
 public class ApplicationConfiguration {
 
     @Bean
-    public CellValueConverter defaultCellValueConverter() {
-        return new DefaultCellValueConverter();
+    public CellValueConverter defaultCellValueConverter(MessageSource messageSource) {
+        return new DefaultCellValueConverter(messageSource);
     }
 
     @Bean
@@ -37,7 +37,9 @@ public class ApplicationConfiguration {
 ```
 
 `CellValueConverter` is responsible for converting objects to values to be written in excel. Users can provided their own implementations and/or use
-`DefaultCellValueConverter`.
+`DefaultCellValueConverter`. `DefaultCellValueConverter` supports writing of dates, numbers and enums to excel (for other types toString() method is called before writing to excel).
+Enum value to be written to excel can be provided through messages.properties file in the form `fullyQualifiedClassName.enumValue.description` and if present will be written to
+excel instead of value.
 
 `TypeDataFormatUtil` is responsible for resolving a list of `TypeDataFormat` instances that decide with what format a specific class will be written to excel. It accepts a list of formats for value
 conversion (`dateFormat`, `dateTimeFormat`, `integerNumberFormat`, `decimalNumberFormat`), option should dates be written with time component or not

--- a/nrich-excel/build.gradle
+++ b/nrich-excel/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   compileOnly "org.projectlombok:lombok"
 
   implementation "org.springframework:spring-core"
+  implementation "org.springframework:spring-context"
   implementation "org.apache.poi:poi"
   implementation "org.apache.poi:poi-ooxml"
 

--- a/nrich-excel/src/main/java/net/croz/nrich/excel/converter/DefaultCellValueConverter.java
+++ b/nrich-excel/src/main/java/net/croz/nrich/excel/converter/DefaultCellValueConverter.java
@@ -21,6 +21,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.croz.nrich.excel.api.converter.CellValueConverter;
 import net.croz.nrich.excel.api.model.CellHolder;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.annotation.Order;
 
 import java.math.BigDecimal;
@@ -36,10 +38,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+@RequiredArgsConstructor
 @Order
 public class DefaultCellValueConverter implements CellValueConverter {
 
+    private static final String ENUM_MESSAGE_FORMAT = "%s.%s.description";
+
     private final List<ConverterHolder> converterHolderList = initializeConverterList();
+
+    private final MessageSource messageSource;
 
     @Override
     public void setCellValue(CellHolder cell, Object value) {
@@ -65,7 +72,8 @@ public class DefaultCellValueConverter implements CellValueConverter {
             new ConverterHolder(Long.class, (cell, value) -> cell.setCellValue(((Number) value).longValue())),
             new ConverterHolder(BigDecimal.class, (cell, value) -> cell.setCellValue(((Number) value).doubleValue())),
             new ConverterHolder(Float.class, (cell, value) -> cell.setCellValue(((Number) value).doubleValue())),
-            new ConverterHolder(Double.class, (cell, value) -> cell.setCellValue(((Number) value).doubleValue()))
+            new ConverterHolder(Double.class, (cell, value) -> cell.setCellValue(((Number) value).doubleValue())),
+            new ConverterHolder(Enum.class, (cell, value) -> cell.setCellValue(resolveEnumValue(value)))
         );
     }
 
@@ -80,6 +88,11 @@ public class DefaultCellValueConverter implements CellValueConverter {
             .orElse(null);
     }
 
+    private String resolveEnumValue(Object value) {
+        String messageCode = String.format(ENUM_MESSAGE_FORMAT, value.getClass().getName(), value);
+
+        return messageSource.getMessage(messageCode, null, value.toString(), LocaleContextHolder.getLocale());
+    }
 
     @RequiredArgsConstructor
     @Getter

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/ExcelTestConfiguration.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/ExcelTestConfiguration.java
@@ -25,8 +25,10 @@ import net.croz.nrich.excel.converter.DefaultCellValueConverter;
 import net.croz.nrich.excel.generator.PoiExcelReportGeneratorFactory;
 import net.croz.nrich.excel.service.DefaultExcelReportService;
 import net.croz.nrich.excel.util.TypeDataFormatUtil;
+import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.io.ResourceLoader;
 
 import java.util.List;
@@ -35,8 +37,17 @@ import java.util.List;
 public class ExcelTestConfiguration {
 
     @Bean
-    public CellValueConverter defaultCellValueConverter() {
-        return new DefaultCellValueConverter();
+    public MessageSource messageSource() {
+        ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+
+        messageSource.setBasename("messages");
+
+        return messageSource;
+    }
+
+    @Bean
+    public CellValueConverter defaultCellValueConverter(MessageSource messageSource) {
+        return new DefaultCellValueConverter(messageSource);
     }
 
     @Bean

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/converter/DefaultCellValueConverterTest.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/converter/DefaultCellValueConverterTest.java
@@ -18,9 +18,11 @@
 package net.croz.nrich.excel.converter;
 
 import net.croz.nrich.excel.api.model.CellHolder;
+import net.croz.nrich.excel.stub.TestEnum;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.context.support.ResourceBundleMessageSource;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -41,7 +43,7 @@ import static org.mockito.Mockito.verify;
 
 class DefaultCellValueConverterTest {
 
-    private final DefaultCellValueConverter defaultCellValueConverter = new DefaultCellValueConverter();
+    private final DefaultCellValueConverter defaultCellValueConverter = new DefaultCellValueConverter(new ResourceBundleMessageSource());
 
     @MethodSource("shouldReturnTrueIfConversionIsSupportedMethodSource")
     @ParameterizedTest
@@ -73,7 +75,8 @@ class DefaultCellValueConverterTest {
             arguments(1L, true),
             arguments(2.2F, true),
             arguments(2.2D, true),
-            arguments(BigDecimal.ONE, true)
+            arguments(BigDecimal.ONE, true),
+            arguments(TestEnum.FIRST, true)
         );
     }
 
@@ -105,7 +108,8 @@ class DefaultCellValueConverterTest {
             arguments(1L, Number.class),
             arguments(2.2F, Number.class),
             arguments(2.2D, Number.class),
-            arguments(BigDecimal.ONE, Number.class)
+            arguments(BigDecimal.ONE, Number.class),
+            arguments(TestEnum.FIRST, String.class)
         );
     }
 }

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorTest.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/generator/PoiExcelReportGeneratorTest.java
@@ -22,10 +22,12 @@ import net.croz.nrich.excel.api.model.ColumnDataFormat;
 import net.croz.nrich.excel.api.model.TemplateVariable;
 import net.croz.nrich.excel.api.model.TypeDataFormat;
 import net.croz.nrich.excel.converter.DefaultCellValueConverter;
+import net.croz.nrich.excel.stub.TestEnum;
 import net.croz.nrich.excel.util.TypeDataFormatUtil;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.support.ResourceBundleMessageSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -63,7 +65,10 @@ class PoiExcelReportGeneratorTest {
 
     @BeforeEach
     void setup() {
-        List<CellValueConverter> cellValueConverterList = Collections.singletonList(new DefaultCellValueConverter());
+        ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("messages");
+
+        List<CellValueConverter> cellValueConverterList = Collections.singletonList(new DefaultCellValueConverter(messageSource));
         InputStream template = this.getClass().getResourceAsStream("/excel/template.xlsx");
         List<TemplateVariable> templateVariableList = Collections.singletonList(new TemplateVariable("templateVariable", "resolvedValue"));
         List<ColumnDataFormat> columnDataFormatList = Arrays.asList(new ColumnDataFormat(2, "dd-MM-yyyy"), new ColumnDataFormat(3, "dd-MM-yyyy HH:mm"));
@@ -85,10 +90,10 @@ class PoiExcelReportGeneratorTest {
         Instant now = Instant.now().truncatedTo(ChronoUnit.DAYS);
         Object[] rowData = new Object[] {
             1.1, "value", new Date(now.toEpochMilli()), ZonedDateTime.now().truncatedTo(ChronoUnit.DAYS), OffsetDateTime.now().truncatedTo(ChronoUnit.DAYS), now, now, 1, 1.5F, (short) 1,
-            LocalDate.now(), LocalDateTime.now().truncatedTo(ChronoUnit.DAYS), BigDecimal.valueOf(1.5), 10L, null
+            LocalDate.now(), LocalDateTime.now().truncatedTo(ChronoUnit.DAYS), BigDecimal.valueOf(1.5), 10L, TestEnum.FIRST, TestEnum.SECOND, null
         };
         // when resolving data from cells all dates are converted to instant, all decimal numbers are converted to double and all whole numbers are converted to integer
-        Object[] expectedRowData = new Object[] { 1.1, "value", now, now, now, now, now, 1, 1.5, 1, now, now, 1.5, 10, null };
+        Object[] expectedRowData = new Object[] { 1.1, "value", now, now, now, now, now, 1, 1.5, 1, now, now, 1.5, 10, "First", "SECOND", null };
 
         // when
         excelReportGenerator.writeRowData(rowData);

--- a/nrich-excel/src/test/java/net/croz/nrich/excel/stub/TestEnum.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/stub/TestEnum.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.excel.stub;
+
+public enum TestEnum {
+    FIRST, SECOND
+}

--- a/nrich-excel/src/test/resources/messages.properties
+++ b/nrich-excel/src/test/resources/messages.properties
@@ -1,0 +1,1 @@
+net.croz.nrich.excel.stub.TestEnum.FIRST.description=First


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.1.1
* Module:
nrich-excel

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add support for resolving enum description from message source when writing enums to excel

### Details

Add support for resolving enum description from message source when writing enums to excel

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
