### PR TITLE
Add support for specifiying join type for projections and restrictions

### DIFF
--- a/nrich-search-api/src/main/java/net/croz/nrich/search/api/model/SearchConfiguration.java
+++ b/nrich-search-api/src/main/java/net/croz/nrich/search/api/model/SearchConfiguration.java
@@ -25,6 +25,7 @@ import net.croz.nrich.search.api.model.property.SearchPropertyConfiguration;
 import net.croz.nrich.search.api.model.property.SearchPropertyMapping;
 import net.croz.nrich.search.api.model.subquery.SubqueryConfiguration;
 
+import jakarta.persistence.criteria.JoinType;
 import java.util.List;
 import java.util.function.Function;
 
@@ -102,6 +103,11 @@ public class SearchConfiguration<T, P, R> {
      * Whether OR operator should be used when building query (default is AND).
      */
     private boolean anyMatch;
+
+    /**
+     * Default join type to be used for projections and conditions. If not specified default is JoinType.INNER
+     */
+    private JoinType defaultJoinType;
 
     @Builder.Default
     private SearchPropertyConfiguration searchPropertyConfiguration = SearchPropertyConfiguration.defaultSearchPropertyConfiguration();

--- a/nrich-search-api/src/main/java/net/croz/nrich/search/api/model/SearchJoin.java
+++ b/nrich-search-api/src/main/java/net/croz/nrich/search/api/model/SearchJoin.java
@@ -47,7 +47,7 @@ public class SearchJoin<R> {
     private String alias;
 
     /**
-     * Type of join (inner or left).
+     * Type of join.
      */
     private JoinType joinType;
 

--- a/nrich-search-api/src/main/java/net/croz/nrich/search/api/model/subquery/SubqueryConfiguration.java
+++ b/nrich-search-api/src/main/java/net/croz/nrich/search/api/model/subquery/SubqueryConfiguration.java
@@ -22,6 +22,8 @@ import lombok.Getter;
 import lombok.Setter;
 import net.croz.nrich.search.api.model.property.SearchPropertyJoin;
 
+import jakarta.persistence.criteria.JoinType;
+
 /**
  * Configuration for subquery. Allows specifying custom root entity, joins and resolving property values from
  * search request either by property prefix or by a separate class holding all subquery restrictions.
@@ -50,5 +52,10 @@ public class SubqueryConfiguration {
      * Name of property that holds all subquery restrictions.
      */
     private String restrictionPropertyHolder;
+
+    /**
+     * Default join type to be used for conditions. If not specified default is JoinType.INNER
+     */
+    private JoinType defaultJoinType;
 
 }

--- a/nrich-search/README.md
+++ b/nrich-search/README.md
@@ -402,6 +402,11 @@ association to `Role`. It is possible to map that connection by using `UserRole`
 
 This configuration will search `UserRole` entity by all properties in `UserSearchRequest` that have a prefix `userRole`.
 
+#### Default join type
+
+[`SearchConfiguration`][search-configuration-url] supports specifying default join type for conditions and projections. If none is specified then inner join is used.
+This can be also customized for individual associations by specifying a `SearchJoin` with `joinType`. Specified `joinType` will then be used when building projections and conditions.
+
 [//]: # (Reference links for readability)
 
 [search-configuration-url]: ../nrich-search-api/src/main/java/net/croz/nrich/search/api/model/SearchConfiguration.java

--- a/nrich-search/src/test/java/net/croz/nrich/search/util/testutil/PathResolvingUtilGeneratingUtil.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/util/testutil/PathResolvingUtilGeneratingUtil.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.search.util.testutil;
+
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.EntityType;
+import java.util.Set;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public final class PathResolvingUtilGeneratingUtil {
+
+    private PathResolvingUtilGeneratingUtil() {
+    }
+
+    public static Root<?> createRootWithCollectionAttribute(String firstPath, String secondPath, Path<?> result, JoinType joinType) {
+        Attribute<?, ?> attribute = mock(Attribute.class);
+        Root<?> root = createRootWithAttribute(firstPath, attribute);
+
+        doReturn(true).when(attribute).isCollection();
+
+        Join<?, ?> second = mock(Join.class);
+        doReturn(second).when(root).join(firstPath, joinType == null ? JoinType.INNER : joinType);
+        doReturn(result).when(second).get(secondPath);
+
+        return root;
+    }
+
+    public static Root<?> createRootWithAssociationAttribute(String firstPath, String secondPath, Path<?> result) {
+        Attribute<?, ?> attribute = mock(Attribute.class);
+        Root<?> root = createRootWithAttribute(firstPath, attribute);
+        Join<?, ?> second = mock(Join.class);
+
+        doReturn(true).when(attribute).isAssociation();
+        doReturn(Set.of(second)).when(root).getJoins();
+        doReturn(attribute).when(second).getAttribute();
+        doReturn(firstPath).when(attribute).getName();
+        doReturn(result).when(second).get(secondPath);
+
+        return root;
+    }
+
+    private static Root<?> createRootWithAttribute(String attributeName, Attribute<?, ?> attribute) {
+        EntityType<?> entityType = mock(EntityType.class);
+        Root<?> root = mock(Root.class);
+
+        doReturn(attribute).when(entityType).getAttribute(attributeName);
+        doReturn(entityType).when(root).getModel();
+
+        return root;
+    }
+}


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:

2.1.1

* Module:
nrich-search, nrich-search-api

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Added support for specifying JoinType when adding projections and conditions to query.

### Details

Added support for specifying JoinType when adding projections and conditions to query. The JoinType can be specified on SearchConfiguration level and overridden on each join by explicitly specifying `SearchJoin`.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
