### PR TITLE
Support resolving of notification content from exception message or message code

### DIFF
--- a/nrich-core-api/src/main/java/net/croz/nrich/core/api/exception/ExceptionWithMessage.java
+++ b/nrich-core-api/src/main/java/net/croz/nrich/core/api/exception/ExceptionWithMessage.java
@@ -15,18 +15,11 @@
  *
  */
 
-package net.croz.nrich.notification.stub;
+package net.croz.nrich.core.api.exception;
 
-import lombok.Getter;
-import net.croz.nrich.core.api.exception.ExceptionWithArguments;
+/**
+ * Marker interface that uses exception message for notification.
+ */
+public interface ExceptionWithMessage {
 
-@Getter
-public class NotificationResolverServiceTestExceptionWithArguments extends RuntimeException implements ExceptionWithArguments {
-
-    private final transient Object[] argumentList;
-
-    public NotificationResolverServiceTestExceptionWithArguments(String message, Object... argumentList) {
-        super(message);
-        this.argumentList = argumentList;
-    }
 }

--- a/nrich-core-api/src/main/java/net/croz/nrich/core/api/exception/ExceptionWithMessageCode.java
+++ b/nrich-core-api/src/main/java/net/croz/nrich/core/api/exception/ExceptionWithMessageCode.java
@@ -15,18 +15,13 @@
  *
  */
 
-package net.croz.nrich.notification.stub;
+package net.croz.nrich.core.api.exception;
 
-import lombok.Getter;
-import net.croz.nrich.core.api.exception.ExceptionWithArguments;
+/**
+ * Implementing this interface enables resolving exception message from <pre>{@code MessageSource}</pre> using supplied message code.
+ */
+public interface ExceptionWithMessageCode {
 
-@Getter
-public class NotificationResolverServiceTestExceptionWithArguments extends RuntimeException implements ExceptionWithArguments {
+    String getMessageCode();
 
-    private final transient Object[] argumentList;
-
-    public NotificationResolverServiceTestExceptionWithArguments(String message, Object... argumentList) {
-        super(message);
-        this.argumentList = argumentList;
-    }
 }

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/BaseNotificationResponseService.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/BaseNotificationResponseService.java
@@ -55,10 +55,9 @@ public interface BaseNotificationResponseService<T> {
      *
      * @param throwable                    exception for which to resolve notification
      * @param additionalNotificationData   additional notification data to add to notification
-     * @param exceptionMessageArgumentList optional exception argument list, will be used when resolving exception message
      * @return response with notification
      */
-    T responseWithExceptionNotification(Throwable throwable, AdditionalNotificationData additionalNotificationData, Object... exceptionMessageArgumentList);
+    T responseWithExceptionNotification(Throwable throwable, AdditionalNotificationData additionalNotificationData);
 
     /**
      * Returns response with {@link net.croz.nrich.notification.api.model.Notification} instance.
@@ -87,8 +86,8 @@ public interface BaseNotificationResponseService<T> {
         return responseWithValidationFailureNotification(exception, AdditionalNotificationData.empty());
     }
 
-    default T responseWithExceptionNotification(Throwable throwable, Object... additionalMessageArgumentList) {
-        return responseWithExceptionNotification(throwable, AdditionalNotificationData.empty(), additionalMessageArgumentList);
+    default T responseWithExceptionNotification(Throwable throwable) {
+        return responseWithExceptionNotification(throwable, AdditionalNotificationData.empty());
     }
 
     default T responseWithNotificationActionResolvedFromRequest() {

--- a/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/NotificationResolverService.java
+++ b/nrich-notification-api/src/main/java/net/croz/nrich/notification/api/service/NotificationResolverService.java
@@ -56,10 +56,9 @@ public interface NotificationResolverService {
      *
      * @param throwable                    exception for which to resolve notification
      * @param additionalNotificationData   additional notification data to add to notification
-     * @param exceptionMessageArgumentList optional exception argument list, will be used when resolving exception message
      * @return {@link Notification} instance
      */
-    Notification createNotificationForException(Throwable throwable, AdditionalNotificationData additionalNotificationData, Object... exceptionMessageArgumentList);
+    Notification createNotificationForException(Throwable throwable, AdditionalNotificationData additionalNotificationData);
 
     /**
      * Returns {@link Notification} instance for action. Default severity is <pre>INFO</pre>. Resolved action message is added as notification content.
@@ -79,8 +78,8 @@ public interface NotificationResolverService {
         return createNotificationForValidationFailure(exception, AdditionalNotificationData.empty());
     }
 
-    default Notification createNotificationForException(Throwable throwable, Object... exceptionMessageArgumentList) {
-        return createNotificationForException(throwable, AdditionalNotificationData.empty(), exceptionMessageArgumentList);
+    default Notification createNotificationForException(Throwable throwable) {
+        return createNotificationForException(throwable, AdditionalNotificationData.empty());
     }
 
     default Notification createNotificationForAction(String actionName) {

--- a/nrich-notification/README.md
+++ b/nrich-notification/README.md
@@ -263,7 +263,11 @@ In [`DefaultNotificationResolverService`][default-notification-resolver-service-
 
 ### Custom exception notification data
 
-Depending on the context of notification creation, if a notification is created while resolving an exception, then the action code is a **fully qualified class name for that exception**.
+Depending on the context of notification creation, if a notification is created while resolving an exception, then the default action code is a **fully qualified class name for that exception**.
+If an exception implements [`ExceptionWithMessageCode`][exception-with-message-code-url] then notification content is resolved through provided message code
+and if an exception implements [`ExceptionWithMessage`][exception-with-message-url] then notification content is equal to exceptions message
+(title is still resolved from fully qualified class name in both cases). If additional arguments are required when resolving message, exception should implement
+[`ExceptionWithArguments`][exception-with-arguments-url].
 
 For example, let's say we have this exception handler:
 
@@ -500,3 +504,9 @@ where we can see that instead of `{0}` the value was interpolated.
 [additional-notification-data-url]: ../nrich-notification-api/src/main/java/net/croz/nrich/notification/api/model/AdditionalNotificationData.java
 
 [default-notification-resolver-service-url]: ../nrich-notification/src/main/java/net/croz/nrich/notification/service/DefaultNotificationResolverService.java
+
+[exception-with-message-code-url]: ../nrich-core-api/src/main/java/net/croz/nrich/core/api/exception/ExceptionWithMessageCode.java
+
+[exception-with-message-url]: ../nrich-core-api/src/main/java/net/croz/nrich/core/api/exception/ExceptionWithMessage.java
+
+[exception-with-arguments-url]: ../nrich-core-api/src/main/java/net/croz/nrich/core/api/exception/ExceptionWithArguments.java

--- a/nrich-notification/build.gradle
+++ b/nrich-notification/build.gradle
@@ -1,6 +1,7 @@
 description = "Provides a unified response format for data returned to clients"
 
 dependencies {
+  api project(":nrich-core-api")
   api project(":nrich-notification-api")
 
   annotationProcessor "org.projectlombok:lombok"

--- a/nrich-notification/src/main/java/net/croz/nrich/notification/service/WebMvcNotificationResponseService.java
+++ b/nrich-notification/src/main/java/net/croz/nrich/notification/service/WebMvcNotificationResponseService.java
@@ -55,8 +55,8 @@ public class WebMvcNotificationResponseService implements NotificationResponseSe
     }
 
     @Override
-    public NotificationResponse responseWithExceptionNotification(Throwable throwable, AdditionalNotificationData additionalNotificationData, Object... exceptionMessageArgumentList) {
-        Notification notification = notificationResolverService.createNotificationForException(throwable, additionalNotificationData, exceptionMessageArgumentList);
+    public NotificationResponse responseWithExceptionNotification(Throwable throwable, AdditionalNotificationData additionalNotificationData) {
+        Notification notification = notificationResolverService.createNotificationForException(throwable, additionalNotificationData);
 
         return new NotificationResponse(notification);
     }

--- a/nrich-notification/src/test/java/net/croz/nrich/notification/service/DefaultNotificationResolverServiceTest.java
+++ b/nrich-notification/src/test/java/net/croz/nrich/notification/service/DefaultNotificationResolverServiceTest.java
@@ -26,6 +26,8 @@ import net.croz.nrich.notification.api.model.ValidationFailureNotification;
 import net.croz.nrich.notification.stub.NotificationResolverServiceTestException;
 import net.croz.nrich.notification.stub.NotificationResolverServiceTestExceptionWithArguments;
 import net.croz.nrich.notification.stub.NotificationResolverServiceTestExceptionWithCustomTitle;
+import net.croz.nrich.notification.stub.NotificationResolverServiceTestExceptionWithMessage;
+import net.croz.nrich.notification.stub.NotificationResolverServiceTestExceptionWithMessageCode;
 import net.croz.nrich.notification.stub.NotificationResolverServiceTestRequest;
 import net.croz.nrich.notification.stub.NotificationResolverServiceTestRequestWithCustomTitle;
 import net.croz.nrich.notification.stub.NotificationResolverServiceTestWithoutMessageRequest;
@@ -157,10 +159,10 @@ class DefaultNotificationResolverServiceTest {
     @Test
     void shouldAddMessageArgumentsForDefinedExceptions() {
         // given
-        Exception exception = new NotificationResolverServiceTestExceptionWithArguments("message");
+        Exception exception = new NotificationResolverServiceTestExceptionWithArguments("message", "1");
 
         // when
-        Notification notification = defaultNotificationResolverService.createNotificationForException(exception, "1");
+        Notification notification = defaultNotificationResolverService.createNotificationForException(exception);
 
         // then
         assertThat(notification).isNotNull();
@@ -322,12 +324,40 @@ class DefaultNotificationResolverServiceTest {
 
     @Test
     void shouldNotFailWithNullArguments() {
-        // when
+        // given
         AdditionalNotificationData notificationData = AdditionalNotificationData.builder().build();
-        Throwable thrown = catchThrowable(() -> defaultNotificationResolverService.createNotificationForException(new RuntimeException(), notificationData, (Object[]) null));
+        Exception exception = new NotificationResolverServiceTestExceptionWithArguments("", (Object[]) null);
+
+        // when
+        Throwable thrown = catchThrowable(() -> defaultNotificationResolverService.createNotificationForException(exception, notificationData));
 
         // then
         assertThat(thrown).isNull();
+    }
+
+    @Test
+    void shouldResolveNotificationContentFromProvidedMessageCode() {
+        // given
+        Exception exception = new NotificationResolverServiceTestExceptionWithMessageCode();
+
+        // when
+        Notification notification = defaultNotificationResolverService.createNotificationForException(exception);
+
+        // then
+        assertThat(notification.getContent()).isEqualTo("Content resolved from message code");
+    }
+
+    @Test
+    void shouldResolveNotificationContentFromProvidedMessage() {
+        // given
+        String messageContent = "Message content";
+        Exception exception = new NotificationResolverServiceTestExceptionWithMessage(messageContent);
+
+        // when
+        Notification notification = defaultNotificationResolverService.createNotificationForException(exception);
+
+        // then
+        assertThat(notification.getContent()).isEqualTo(messageContent);
     }
 
     private BindingResult validate(Object objectToValidate, Map<String, Object> valueMap) {

--- a/nrich-notification/src/test/java/net/croz/nrich/notification/stub/NotificationResolverServiceTestExceptionWithMessage.java
+++ b/nrich-notification/src/test/java/net/croz/nrich/notification/stub/NotificationResolverServiceTestExceptionWithMessage.java
@@ -17,16 +17,11 @@
 
 package net.croz.nrich.notification.stub;
 
-import lombok.Getter;
-import net.croz.nrich.core.api.exception.ExceptionWithArguments;
+import net.croz.nrich.core.api.exception.ExceptionWithMessage;
 
-@Getter
-public class NotificationResolverServiceTestExceptionWithArguments extends RuntimeException implements ExceptionWithArguments {
+public class NotificationResolverServiceTestExceptionWithMessage extends RuntimeException implements ExceptionWithMessage {
 
-    private final transient Object[] argumentList;
-
-    public NotificationResolverServiceTestExceptionWithArguments(String message, Object... argumentList) {
+    public NotificationResolverServiceTestExceptionWithMessage(String message) {
         super(message);
-        this.argumentList = argumentList;
     }
 }

--- a/nrich-notification/src/test/java/net/croz/nrich/notification/stub/NotificationResolverServiceTestExceptionWithMessageCode.java
+++ b/nrich-notification/src/test/java/net/croz/nrich/notification/stub/NotificationResolverServiceTestExceptionWithMessageCode.java
@@ -17,16 +17,12 @@
 
 package net.croz.nrich.notification.stub;
 
-import lombok.Getter;
-import net.croz.nrich.core.api.exception.ExceptionWithArguments;
+import net.croz.nrich.core.api.exception.ExceptionWithMessageCode;
 
-@Getter
-public class NotificationResolverServiceTestExceptionWithArguments extends RuntimeException implements ExceptionWithArguments {
+public class NotificationResolverServiceTestExceptionWithMessageCode extends RuntimeException implements ExceptionWithMessageCode {
 
-    private final transient Object[] argumentList;
-
-    public NotificationResolverServiceTestExceptionWithArguments(String message, Object... argumentList) {
-        super(message);
-        this.argumentList = argumentList;
+    @Override
+    public String getMessageCode() {
+        return "notification-with-custom-message-code.content";
     }
 }

--- a/nrich-notification/src/test/resources/messages.properties
+++ b/nrich-notification/src/test/resources/messages.properties
@@ -1,3 +1,20 @@
+#
+#  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
 notification.success.title=Success
 notification.success.default-message=Action has been executed
 notification.validation-failed.title=Validation failed
@@ -20,8 +37,9 @@ net.croz.nrich.notification.stub.NotificationResolverServiceTestException.severi
 net.croz.nrich.notification.stub.NotificationResolverServiceTestExceptionWithArguments.content=Error message with arguments: {0}
 
 net.croz.nrich.notification.stub.NotificationResolverServiceTestExceptionWithCustomTitle.title=Custom error title
-
 net.croz.nrich.notification.stub.NotificationResolverServiceTestRequestWithCustomTitle.title=Validation failure custom title
+
+notification-with-custom-message-code.content=Content resolved from message code
 
 upload.finished.content=Upload finished
 upload.finished.with-title.content=Upload finished

--- a/nrich-webmvc/build.gradle
+++ b/nrich-webmvc/build.gradle
@@ -1,7 +1,6 @@
 description = "Provides @RestControllerAdvice for exception logging and notification resolving and additional serialization and locale features"
 
 dependencies {
-  api project(":nrich-core-api")
   api project(":nrich-logging-api")
   api project(":nrich-notification-api")
   api project(":nrich-webmvc-api")

--- a/nrich-webmvc/src/main/java/net/croz/nrich/webmvc/advice/NotificationErrorHandlingRestControllerAdvice.java
+++ b/nrich-webmvc/src/main/java/net/croz/nrich/webmvc/advice/NotificationErrorHandlingRestControllerAdvice.java
@@ -18,7 +18,6 @@
 package net.croz.nrich.webmvc.advice;
 
 import lombok.RequiredArgsConstructor;
-import net.croz.nrich.core.api.exception.ExceptionWithArguments;
 import net.croz.nrich.logging.api.service.LoggingService;
 import net.croz.nrich.notification.api.model.AdditionalNotificationData;
 import net.croz.nrich.notification.api.service.BaseNotificationResponseService;
@@ -111,9 +110,8 @@ public class NotificationErrorHandlingRestControllerAdvice {
 
         HttpStatus status = resolveHttpStatusForException(unwrappedException, HttpStatus.INTERNAL_SERVER_ERROR);
         AdditionalNotificationData additionalNotificationData = AdditionalNotificationData.builder().messageListDataMap(notificationAuxiliaryData).build();
-        Object[] argumentList = resolveExceptionArgumentList(unwrappedException);
 
-        return ResponseEntity.status(status).body(notificationResponseService.responseWithExceptionNotification(unwrappedException, additionalNotificationData, argumentList));
+        return ResponseEntity.status(status).body(notificationResponseService.responseWithExceptionNotification(unwrappedException, additionalNotificationData));
     }
 
     private Exception unwrapException(Exception exception) {
@@ -128,10 +126,6 @@ public class NotificationErrorHandlingRestControllerAdvice {
         Map<String, Object> exceptionAuxiliaryData = resolveExceptionAuxiliaryData(exception, request);
 
         loggingService.logInternalException(exception, exceptionAuxiliaryData);
-    }
-
-    private Object[] resolveExceptionArgumentList(Exception exception) {
-        return exception instanceof ExceptionWithArguments ? ((ExceptionWithArguments) exception).getArgumentList() : null;
     }
 
     private Map<String, Object> resolveExceptionAuxiliaryData(Exception exception, HttpServletRequest request) {


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.1.1
* Module:
nrich-notification, nrich-webmvc

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add support for resolving of notification content from message or message code for exceptions

### Details

Add support for resolving of notification content from message or message code for exceptions, move handling of exception arguments to NotificationResolver service

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Breaking change (fix, enhancement or feature that would cause existing functionality to change in backward-incompatible way)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
