### PR TITLE
Avoid lazy init exception in DefaultRegistryDataService 

### DIFF
--- a/nrich-registry/src/main/java/net/croz/nrich/registry/data/service/DefaultRegistryDataService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/data/service/DefaultRegistryDataService.java
@@ -25,6 +25,7 @@ import net.croz.nrich.registry.api.data.service.RegistryDataService;
 import net.croz.nrich.registry.core.model.RegistryDataConfiguration;
 import net.croz.nrich.registry.core.model.RegistryDataConfigurationHolder;
 import net.croz.nrich.registry.core.support.ManagedTypeWrapper;
+import net.croz.nrich.registry.data.util.HibernateUtil;
 import net.croz.nrich.search.api.converter.StringToEntityPropertyMapConverter;
 import net.croz.nrich.search.api.model.SearchConfiguration;
 import net.croz.nrich.search.api.model.property.SearchPropertyConfiguration;
@@ -104,7 +105,7 @@ public class DefaultRegistryDataService implements RegistryDataService {
 
         modelMapper.map(entityData, instance);
 
-        return entityManager.merge(instance);
+        return mergeAndInitializeEntity(instance);
     }
 
     @Transactional
@@ -129,7 +130,7 @@ public class DefaultRegistryDataService implements RegistryDataService {
 
         modelMapper.map(entityData, instance);
 
-        return entityManager.merge(instance);
+        return mergeAndInitializeEntity(instance);
     }
 
     @Transactional
@@ -216,5 +217,13 @@ public class DefaultRegistryDataService implements RegistryDataService {
         Map<String, Object> idValueMap = Collections.singletonMap(managedTypeWrapper.getIdAttributeName(), id);
 
         modelMapper.map(idValueMap, entityData);
+    }
+
+    private <T> T mergeAndInitializeEntity(T instance) {
+        T mergedInstance = entityManager.merge(instance);
+
+        HibernateUtil.initialize(mergedInstance);
+
+        return mergedInstance;
     }
 }

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/data/util/HibernateUtil.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/data/util/HibernateUtil.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.registry.data.util;
+
+import lombok.SneakyThrows;
+import org.hibernate.Hibernate;
+import org.hibernate.proxy.HibernateProxy;
+import org.springframework.beans.BeanUtils;
+
+import jakarta.persistence.Entity;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public final class HibernateUtil {
+
+    private static final String PROPERTY_PATH_FORMAT = "%s.%s";
+
+    private static final String COLLECTION_ELEMENT_NAME_FORMAT = "%s-%s";
+
+    private HibernateUtil() {
+    }
+
+    public static void initialize(Object entity) {
+        initializeInternal(entity, null, new ArrayList<>());
+    }
+
+    private static void initializeInternal(Object entity, String propertyPath, List<String> alreadyInitializedProperties) {
+        if (entity == null || alreadyInitializedProperties.contains(propertyPath)) {
+            return;
+        }
+
+        Class<?> entityType = resolveEntityType(entity);
+
+        if (!isManagedType(entityType)) {
+            return;
+        }
+
+        if (!Hibernate.isInitialized(entity)) {
+            Hibernate.initialize(entity);
+        }
+
+        alreadyInitializedProperties.add(propertyPath);
+
+        Arrays.stream(BeanUtils.getPropertyDescriptors(entityType)).forEach(propertyDescriptor -> {
+            String propertyName = propertyDescriptor.getName();
+            Object propertyValue = getPropertyValue(entity, propertyDescriptor);
+
+            if (propertyValue instanceof Collection<?> collection) {
+                int index = 0;
+                for (Object collectionElementValue : collection) {
+                    String collectionElementPropertyName = String.format(COLLECTION_ELEMENT_NAME_FORMAT, propertyName, index++);
+                    String calculatedPropertyPath = calculatePropertyPath(propertyPath, collectionElementPropertyName);
+
+                    initializeInternal(collectionElementValue, calculatedPropertyPath, alreadyInitializedProperties);
+                }
+            }
+            else {
+                String calculatedPropertyPath = calculatePropertyPath(propertyPath, propertyName);
+
+                initializeInternal(propertyValue, calculatedPropertyPath, alreadyInitializedProperties);
+            }
+        });
+    }
+
+    @SneakyThrows
+    private static Object getPropertyValue(Object entity, PropertyDescriptor propertyDescriptor) {
+        Method method = propertyDescriptor.getReadMethod();
+
+        if (method == null) {
+            return null;
+        }
+
+        return method.invoke(entity);
+    }
+
+    private static Class<?> resolveEntityType(Object entity) {
+        Class<?> type = entity.getClass();
+
+        if (entity instanceof HibernateProxy hibernateProxy) {
+            type = hibernateProxy.getHibernateLazyInitializer().getPersistentClass();
+        }
+
+        return type;
+    }
+
+    private static boolean isManagedType(Class<?> entityType) {
+        return entityType.getAnnotation(Entity.class) != null;
+    }
+
+    private static String calculatePropertyPath(String existingPropertyPath, String propertyName) {
+        return existingPropertyPath == null ? propertyName : String.format(PROPERTY_PATH_FORMAT, existingPropertyPath, propertyName);
+    }
+}

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/controller/RegistryDataControllerTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/controller/RegistryDataControllerTest.java
@@ -26,7 +26,6 @@ import net.croz.nrich.registry.data.stub.RegistryTestEmbeddedUserGroup;
 import net.croz.nrich.registry.data.stub.RegistryTestEntity;
 import net.croz.nrich.registry.test.BaseControllerTest;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.ResultActions;
@@ -40,6 +39,7 @@ import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.c
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createDeleteRegistryRequest;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createListRegistryRequest;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createRegistryRequest;
+import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createRegistryRequestWithAssociation;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createRegistryTestEmbeddedUserGroup;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createRegistryTestEntity;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createRegistryTestEntityList;
@@ -106,6 +106,21 @@ class RegistryDataControllerTest extends BaseControllerTest {
         // then
         result.andExpect(status().isOk())
             .andExpect(jsonPath("$.name").value(entityName));
+    }
+
+    @Test
+    void shouldCreateRegistryEntityWithInitializedAssociation() throws Exception {
+        // given
+        RegistryTestEntity entity = executeInTransaction(platformTransactionManager, () -> createRegistryTestEntity(entityManager));
+        String requestUrl = fullUrl("create");
+        CreateRegistryRequest request = createRegistryRequestWithAssociation(objectMapper, REGISTRY_TYPE_NAME, entity);
+
+        // when
+        ResultActions result = performPostRequest(requestUrl, request);
+
+        // then
+        result.andExpect(status().isOk())
+            .andExpect(jsonPath("$.parent.id").value(entity.getId()));
     }
 
     @Test
@@ -228,8 +243,6 @@ class RegistryDataControllerTest extends BaseControllerTest {
         result.andExpect(status().isOk());
     }
 
-    // TODO enable when https://hibernate.atlassian.net/browse/HHH-15875 is solved.
-    @Disabled
     @Test
     void shouldNotFailListingRegistryWithLazyAssociationsInEmbeddedId() throws Exception {
         // given

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataGeneratingUtil.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataGeneratingUtil.java
@@ -181,6 +181,16 @@ public final class RegistryDataGeneratingUtil {
     }
 
     @SneakyThrows
+    public static CreateRegistryRequest createRegistryRequestWithAssociation(ObjectMapper objectMapper, String classFullName, RegistryTestEntity parent) {
+        CreateRegistryRequest request = new CreateRegistryRequest();
+
+        request.setClassFullName(classFullName);
+        request.setJsonEntityData(objectMapper.writeValueAsString(Map.of("name", "name", "age", 40, "parent", parent)));
+
+        return request;
+    }
+
+    @SneakyThrows
     public static CreateRegistryRequest createRegistryRequest(ObjectMapper objectMapper, String classFullName, String name, Integer age) {
         CreateRegistryRequest request = new CreateRegistryRequest();
 

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/util/HibernateUtilTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/util/HibernateUtilTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.registry.data.util;
+
+import net.croz.nrich.registry.RegistryTestConfiguration;
+import net.croz.nrich.registry.data.util.stub.HibernateUtilTestEntity;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import static net.croz.nrich.registry.data.util.testutil.HibernateUtilGeneratingUtil.createAndSaveHibernateUtilTestEntity;
+import static net.croz.nrich.registry.testutil.PersistenceTestUtil.executeInTransaction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+@SpringJUnitWebConfig(RegistryTestConfiguration.class)
+class HibernateUtilTest {
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void shouldInitializeEntity() {
+        // given
+        HibernateUtilTestEntity entity = executeInTransaction(transactionManager, () -> createAndSaveHibernateUtilTestEntity(entityManager));
+
+        // when
+        HibernateUtilTestEntity loadedEntity = loadAndInitializeEntity(entity.getId());
+
+        // and when
+        Exception exception = catchException(() -> {
+            loadedEntity.getParent().getId();
+            loadedEntity.getChildren().get(0).getId();
+        });
+
+        // then
+        assertThat(exception).isNull();
+    }
+
+    private HibernateUtilTestEntity loadAndInitializeEntity(Long id) {
+        return executeInTransaction(transactionManager, () -> {
+            HibernateUtilTestEntity loadedEntity = entityManager.find(HibernateUtilTestEntity.class, id);
+
+            HibernateUtil.initialize(loadedEntity);
+
+            return loadedEntity;
+        });
+    }
+}

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/util/stub/HibernateUtilTestEntity.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/util/stub/HibernateUtilTestEntity.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.registry.data.util.stub;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+
+@Setter
+@Getter
+@Entity
+public class HibernateUtilTestEntity {
+
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Id
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private HibernateUtilTestEntity parent;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    private List<HibernateUtilTestEntity> children;
+
+    @Getter(AccessLevel.NONE)
+    private String hiddenName;
+
+}

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/util/testutil/HibernateUtilGeneratingUtil.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/util/testutil/HibernateUtilGeneratingUtil.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.registry.data.util.testutil;
+
+import net.croz.nrich.registry.data.util.stub.HibernateUtilTestEntity;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+
+public final class HibernateUtilGeneratingUtil {
+
+    private HibernateUtilGeneratingUtil() {
+    }
+
+    public static HibernateUtilTestEntity createAndSaveHibernateUtilTestEntity(EntityManager entityManager) {
+        HibernateUtilTestEntity firstChild = createHibernateUtilTestEntityInternal(entityManager, "first", null, null);
+        HibernateUtilTestEntity secondChild = createHibernateUtilTestEntityInternal(entityManager, "second", null, null);
+        HibernateUtilTestEntity parent = createHibernateUtilTestEntityInternal(entityManager, "parent", null, null);
+
+        return createHibernateUtilTestEntityInternal(entityManager, "main", parent, List.of(firstChild, secondChild));
+    }
+
+    private static HibernateUtilTestEntity createHibernateUtilTestEntityInternal(EntityManager entityManager, String name, HibernateUtilTestEntity parent, List<HibernateUtilTestEntity> children) {
+        HibernateUtilTestEntity entity = new HibernateUtilTestEntity();
+
+        entity.setName(name);
+        entity.setParent(parent);
+        entity.setChildren(children);
+
+        entityManager.persist(entity);
+
+        return entity;
+    }
+}


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.1.1
* Module:
nrich-registry

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

Add entity initialization when returning a value from create or update method in DefaultRegistryDataService to avoid lazy init exception.

### Summary

<!--- Please, provide a short summary of your changes. -->

### Details

<!--- Please, describe your changes in detail. -->

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
