### PR TITLE
Support  programmatically registered constraints on Hibernate entities

### DIFF
--- a/nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfiguration.java
+++ b/nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfiguration.java
@@ -22,13 +22,16 @@ import net.croz.nrich.validation.api.mapping.ConstraintValidatorRegistrar;
 import net.croz.nrich.validation.constraint.mapping.DefaultConstraintValidatorRegistrar;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.boot.autoconfigure.validation.ValidationConfigurationCustomizer;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.AbstractResourceBasedMessageSource;
 
+import jakarta.validation.Validator;
 import java.util.List;
 
 @Configuration(proxyBeanMethods = false)
@@ -65,5 +68,12 @@ public class NrichValidationAutoConfiguration {
     @Bean
     ValidationConfigurationCustomizer validationConfigurationCustomizer(ConstraintValidatorRegistrar constraintValidatorRegistrar) {
         return constraintValidatorRegistrar::registerConstraintValidators;
+    }
+
+    @ConditionalOnBean(Validator.class)
+    @ConditionalOnProperty(name = "nrich.validation.register-constraint-validators", havingValue = "true", matchIfMissing = true)
+    @Bean
+    HibernatePropertiesCustomizer validationHibernatePropertiesCustomizer(Validator validator) {
+        return hibernateProperties -> hibernateProperties.put("jakarta.persistence.validation.factory", validator);
     }
 }

--- a/nrich-validation-spring-boot-starter/src/test/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfigurationTest.java
+++ b/nrich-validation-spring-boot-starter/src/test/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfigurationTest.java
@@ -20,10 +20,12 @@ package net.croz.nrich.validation.starter.configuration;
 import net.croz.nrich.validation.api.mapping.ConstraintValidatorRegistrar;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.boot.autoconfigure.validation.ValidationConfigurationCustomizer;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.MessageSource;
 import org.springframework.context.support.AbstractResourceBasedMessageSource;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -37,11 +39,16 @@ class NrichValidationAutoConfigurationTest {
     void shouldConfigureDefaultConfiguration() {
         // expect
         contextRunner.run(context -> {
-                assertThat(context).hasSingleBean(NrichValidationAutoConfiguration.ValidationMessageSourceRegistrar.class);
+            assertThat(context).hasSingleBean(NrichValidationAutoConfiguration.ValidationMessageSourceRegistrar.class);
             assertThat(context).hasSingleBean(ConstraintValidatorRegistrar.class);
-                assertThat(context).hasSingleBean(ValidationConfigurationCustomizer.class);
-            }
-        );
+            assertThat(context).hasSingleBean(ValidationConfigurationCustomizer.class);
+        });
+    }
+
+    @Test
+    void shouldRegisterValidationPropertiesCustomizer() {
+        // expect
+        contextRunner.withBean(LocalValidatorFactoryBean.class).run(context -> assertThat(context).hasSingleBean(HibernatePropertiesCustomizer.class));
     }
 
     @Test


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.1.1
* Module:
nrich-validation-spring-boot-starter

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add support for programmatically registered constraints on hibernate entites by registering Spring's validator with Hibernate BeanValidationEventListener.

### Details

Add support for programmatically registered constraints on hibernate entites by registering Spring's validator with Hibernate BeanValidationEventListener.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
-  ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
