### PR TITLE
Fallback to search by association id when association name has been sent as property name

### DIFF
--- a/nrich-registry/src/main/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationService.java
@@ -1,305 +1,305 @@
-/*
- *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- */
+    /*
+     *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+     *
+     *  Licensed under the Apache License, Version 2.0 (the "License");
+     *  you may not use this file except in compliance with the License.
+     *  You may obtain a copy of the License at
+     *
+     *      https://www.apache.org/licenses/LICENSE-2.0
+     *
+     *  Unless required by applicable law or agreed to in writing, software
+     *  distributed under the License is distributed on an "AS IS" BASIS,
+     *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     *  See the License for the specific language governing permissions and
+     *  limitations under the License.
+     *
+     */
 
-package net.croz.nrich.registry.configuration.service;
+    package net.croz.nrich.registry.configuration.service;
 
-import lombok.RequiredArgsConstructor;
-import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
-import net.croz.nrich.registry.api.configuration.model.RegistryEntityConfiguration;
-import net.croz.nrich.registry.api.configuration.model.RegistryGroupConfiguration;
-import net.croz.nrich.registry.api.configuration.model.property.RegistryPropertyConfiguration;
-import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
-import net.croz.nrich.registry.api.core.model.RegistryOverrideConfiguration;
-import net.croz.nrich.registry.configuration.comparator.RegistryGroupConfigurationComparator;
-import net.croz.nrich.registry.configuration.comparator.RegistryPropertyComparator;
-import net.croz.nrich.registry.configuration.constants.RegistryConfigurationConstants;
-import net.croz.nrich.registry.core.constants.RegistryCoreConstants;
-import net.croz.nrich.registry.core.constants.RegistryEnversConstants;
-import net.croz.nrich.registry.core.model.PropertyWithType;
-import net.croz.nrich.registry.core.model.RegistryGroupDefinitionHolder;
-import net.croz.nrich.registry.core.model.RegistryHistoryConfigurationHolder;
-import net.croz.nrich.registry.core.support.ManagedTypeWrapper;
-import net.croz.nrich.registry.core.util.AnnotationUtil;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.context.MessageSource;
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
+    import lombok.RequiredArgsConstructor;
+    import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
+    import net.croz.nrich.registry.api.configuration.model.RegistryEntityConfiguration;
+    import net.croz.nrich.registry.api.configuration.model.RegistryGroupConfiguration;
+    import net.croz.nrich.registry.api.configuration.model.property.RegistryPropertyConfiguration;
+    import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
+    import net.croz.nrich.registry.api.core.model.RegistryOverrideConfiguration;
+    import net.croz.nrich.registry.configuration.comparator.RegistryGroupConfigurationComparator;
+    import net.croz.nrich.registry.configuration.comparator.RegistryPropertyComparator;
+    import net.croz.nrich.registry.configuration.constants.RegistryConfigurationConstants;
+    import net.croz.nrich.registry.core.constants.RegistryCoreConstants;
+    import net.croz.nrich.registry.core.constants.RegistryEnversConstants;
+    import net.croz.nrich.registry.core.model.PropertyWithType;
+    import net.croz.nrich.registry.core.model.RegistryGroupDefinitionHolder;
+    import net.croz.nrich.registry.core.model.RegistryHistoryConfigurationHolder;
+    import net.croz.nrich.registry.core.support.ManagedTypeWrapper;
+    import net.croz.nrich.registry.core.util.AnnotationUtil;
+    import org.apache.commons.lang3.StringUtils;
+    import org.springframework.cache.annotation.Cacheable;
+    import org.springframework.context.MessageSource;
+    import org.springframework.context.i18n.LocaleContextHolder;
+    import org.springframework.context.support.DefaultMessageSourceResolvable;
 
-import jakarta.persistence.metamodel.Attribute;
-import jakarta.persistence.metamodel.ManagedType;
-import jakarta.persistence.metamodel.SingularAttribute;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
+    import jakarta.persistence.metamodel.Attribute;
+    import jakarta.persistence.metamodel.ManagedType;
+    import jakarta.persistence.metamodel.SingularAttribute;
+    import java.math.BigDecimal;
+    import java.util.ArrayList;
+    import java.util.Arrays;
+    import java.util.Collections;
+    import java.util.Comparator;
+    import java.util.List;
+    import java.util.Locale;
+    import java.util.Map;
+    import java.util.Optional;
+    import java.util.function.Predicate;
+    import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
-public class DefaultRegistryConfigurationService implements RegistryConfigurationService {
+    @RequiredArgsConstructor
+    public class DefaultRegistryConfigurationService implements RegistryConfigurationService {
 
-    private final MessageSource messageSource;
+        private final MessageSource messageSource;
 
-    private final List<String> readOnlyPropertyList;
+        private final List<String> readOnlyPropertyList;
 
-    private final RegistryGroupDefinitionHolder registryGroupDefinitionHolder;
+        private final RegistryGroupDefinitionHolder registryGroupDefinitionHolder;
 
-    private final RegistryHistoryConfigurationHolder registryHistoryConfiguration;
+        private final RegistryHistoryConfigurationHolder registryHistoryConfiguration;
 
-    private final Map<Class<?>, RegistryOverrideConfiguration> registryOverrideConfigurationMap;
+        private final Map<Class<?>, RegistryOverrideConfiguration> registryOverrideConfigurationMap;
 
-    private final JavaToJavascriptTypeConversionService javaToJavascriptTypeConversionService;
+        private final JavaToJavascriptTypeConversionService javaToJavascriptTypeConversionService;
 
-    @Cacheable("nrich.registryConfiguration.cache")
-    @Override
-    public List<RegistryGroupConfiguration> fetchRegistryGroupConfigurationList() {
-        List<RegistryGroupConfiguration> registryGroupConfigurationList = new ArrayList<>();
+        @Cacheable("nrich.registryConfiguration.cache")
+        @Override
+        public List<RegistryGroupConfiguration> fetchRegistryGroupConfigurationList() {
+            List<RegistryGroupConfiguration> registryGroupConfigurationList = new ArrayList<>();
 
-        List<RegistryPropertyConfiguration> registryPropertyHistoryConfigurationList = resolveHistoryPropertyList(registryHistoryConfiguration);
+            List<RegistryPropertyConfiguration> registryPropertyHistoryConfigurationList = resolveHistoryPropertyList(registryHistoryConfiguration);
 
-        registryGroupDefinitionHolder.getGroupDefinitionList().forEach(registryGroupDefinition -> {
-            String registryGroupIdDisplayName = groupDisplayLabel(registryGroupDefinition.getRegistryGroupId());
+            registryGroupDefinitionHolder.getGroupDefinitionList().forEach(registryGroupDefinition -> {
+                String registryGroupIdDisplayName = groupDisplayLabel(registryGroupDefinition.getRegistryGroupId());
 
-            List<RegistryEntityConfiguration> configurationList = registryGroupDefinition.getRegistryEntityList().stream()
-                .map(managedType -> resolveRegistryConfiguration(registryGroupDefinition.getRegistryGroupId(), managedType, registryPropertyHistoryConfigurationList))
-                .sorted(Comparator.comparing(RegistryEntityConfiguration::getClassFullName))
-                .collect(Collectors.toList());
+                List<RegistryEntityConfiguration> configurationList = registryGroupDefinition.getRegistryEntityList().stream()
+                    .map(managedType -> resolveRegistryConfiguration(registryGroupDefinition.getRegistryGroupId(), managedType, registryPropertyHistoryConfigurationList))
+                    .sorted(Comparator.comparing(RegistryEntityConfiguration::getClassFullName))
+                    .collect(Collectors.toList());
 
-            RegistryGroupConfiguration registryConfiguration = new RegistryGroupConfiguration(registryGroupDefinition.getRegistryGroupId(), registryGroupIdDisplayName, configurationList);
+                RegistryGroupConfiguration registryConfiguration = new RegistryGroupConfiguration(registryGroupDefinition.getRegistryGroupId(), registryGroupIdDisplayName, configurationList);
 
-            registryGroupConfigurationList.add(registryConfiguration);
-        });
+                registryGroupConfigurationList.add(registryConfiguration);
+            });
 
-        registryGroupConfigurationList.sort(new RegistryGroupConfigurationComparator(registryGroupDefinitionHolder.getGroupDisplayOrderList()));
+            registryGroupConfigurationList.sort(new RegistryGroupConfigurationComparator(registryGroupDefinitionHolder.getGroupDisplayOrderList()));
 
-        return registryGroupConfigurationList;
-    }
-
-    private RegistryEntityConfiguration resolveRegistryConfiguration(String groupId, ManagedTypeWrapper managedTypeWrapper, List<RegistryPropertyConfiguration> historyPropertyConfigurationList) {
-        Class<?> entityType = managedTypeWrapper.getJavaType();
-        RegistryOverrideConfiguration registryOverrideConfiguration = resolveRegistryOverrideConfiguration(entityType, registryOverrideConfigurationMap);
-
-        String registryDisplayName = registryDisplayLabel(entityType);
-        boolean isHistoryAvailable = registryOverrideConfiguration.isHistoryAvailable() || isAudited(entityType);
-        List<RegistryPropertyConfiguration> registryPropertyConfigurationList = resolveRegistryPropertyListForType(managedTypeWrapper, registryOverrideConfiguration);
-        List<RegistryPropertyConfiguration> registryEmbeddedIdPropertyConfigurationList = resolverEmbeddedIdPropertyConfigurationList(managedTypeWrapper, registryOverrideConfiguration);
-        List<String> registryPropertyDisplayOrderList = Optional.ofNullable(registryOverrideConfiguration.getPropertyDisplayOrderList()).orElse(Collections.emptyList());
-
-        registryPropertyConfigurationList.sort(new RegistryPropertyComparator(registryPropertyDisplayOrderList));
-
-        return RegistryEntityConfiguration.builder()
-            .groupId(groupId)
-            .classFullName(entityType.getName())
-            .name(entityType.getSimpleName())
-            .displayName(registryDisplayName)
-            .propertyConfigurationList(registryPropertyConfigurationList)
-            .embeddedIdPropertyConfigurationList(registryEmbeddedIdPropertyConfigurationList)
-            .historyPropertyConfigurationList(historyPropertyConfigurationList)
-            .readOnly(registryOverrideConfiguration.isReadOnly())
-            .creatable(registryOverrideConfiguration.isCreatable())
-            .updateable(registryOverrideConfiguration.isUpdateable())
-            .deletable(registryOverrideConfiguration.isDeletable())
-            .isHistoryAvailable(isHistoryAvailable)
-            .isIdentifierAssigned(managedTypeWrapper.isIdentifierAssigned())
-            .isIdClassIdentity(managedTypeWrapper.isIdClassIdentifier())
-            .isEmbeddedIdentity(managedTypeWrapper.isEmbeddedIdentifier())
-            .idClassPropertyNameList(managedTypeWrapper.getIdClassPropertyNameList())
-            .build();
-    }
-
-    private List<RegistryPropertyConfiguration> resolveRegistryPropertyListForType(ManagedTypeWrapper managedTypeWrapper, RegistryOverrideConfiguration registryOverrideConfiguration) {
-        Predicate<String> isIdAttributePredicate = attributeName -> attributeName.equals(managedTypeWrapper.getIdAttributeName())
-            || managedTypeWrapper.getIdClassPropertyNameList().contains(attributeName);
-
-        return resolveManagedTypePropertyList(
-            managedTypeWrapper.getIdentifiableType(), managedTypeWrapper.getIdentifiableType().getJavaType(), null,
-            isIdAttributePredicate, !managedTypeWrapper.isIdentifierAssigned(), registryOverrideConfiguration
-        );
-    }
-
-    private List<RegistryPropertyConfiguration> resolverEmbeddedIdPropertyConfigurationList(ManagedTypeWrapper managedTypeWrapper, RegistryOverrideConfiguration registryOverrideConfiguration) {
-        if (!managedTypeWrapper.isEmbeddedIdentifier()) {
-            return Collections.emptyList();
+            return registryGroupConfigurationList;
         }
 
-        return resolveManagedTypePropertyList(
-            managedTypeWrapper.getEmbeddableIdType(), managedTypeWrapper.getIdentifiableType().getJavaType(), managedTypeWrapper.getIdAttributeName(),
-            attribute -> false, true, registryOverrideConfiguration
-        );
-    }
+        private RegistryEntityConfiguration resolveRegistryConfiguration(String groupId, ManagedTypeWrapper managedTypeWrapper, List<RegistryPropertyConfiguration> historyPropertyConfigurationList) {
+            Class<?> entityType = managedTypeWrapper.getJavaType();
+            RegistryOverrideConfiguration registryOverrideConfiguration = resolveRegistryOverrideConfiguration(entityType, registryOverrideConfigurationMap);
 
-    private List<RegistryPropertyConfiguration> resolveManagedTypePropertyList(ManagedType<?> managedType, Class<?> entityType, String prefix, Predicate<String> isIdAttributePredicate,
-                                                                               boolean isIdReadOnly, RegistryOverrideConfiguration registryOverrideConfiguration) {
-        List<String> ignoredPropertyList = Optional.ofNullable(registryOverrideConfiguration.getIgnoredPropertyList()).orElse(Collections.emptyList());
-        List<String> readOnlyOverridePropertyList = Optional.ofNullable(registryOverrideConfiguration.getNonEditablePropertyList()).orElse(Collections.emptyList());
-        List<String> nonSortablePropertyList = Optional.ofNullable(registryOverrideConfiguration.getNonSortablePropertyList()).orElse(Collections.emptyList());
-        List<String> nonSearchablePropertyList = Optional.ofNullable(registryOverrideConfiguration.getNonSearchablePropertyList()).orElse(Collections.emptyList());
+            String registryDisplayName = registryDisplayLabel(entityType);
+            boolean isHistoryAvailable = registryOverrideConfiguration.isHistoryAvailable() || isAudited(entityType);
+            List<RegistryPropertyConfiguration> registryPropertyConfigurationList = resolveRegistryPropertyListForType(managedTypeWrapper, registryOverrideConfiguration);
+            List<RegistryPropertyConfiguration> registryEmbeddedIdPropertyConfigurationList = resolverEmbeddedIdPropertyConfigurationList(managedTypeWrapper, registryOverrideConfiguration);
+            List<String> registryPropertyDisplayOrderList = Optional.ofNullable(registryOverrideConfiguration.getPropertyDisplayOrderList()).orElse(Collections.emptyList());
 
-        List<RegistryPropertyConfiguration> registryPropertyConfigurationList = new ArrayList<>();
+            registryPropertyConfigurationList.sort(new RegistryPropertyComparator(registryPropertyDisplayOrderList));
 
-        managedType.getAttributes().forEach(attribute -> {
-            if (shouldSkipAttribute(ignoredPropertyList, attribute)) {
-                return;
+            return RegistryEntityConfiguration.builder()
+                .groupId(groupId)
+                .classFullName(entityType.getName())
+                .name(entityType.getSimpleName())
+                .displayName(registryDisplayName)
+                .propertyConfigurationList(registryPropertyConfigurationList)
+                .embeddedIdPropertyConfigurationList(registryEmbeddedIdPropertyConfigurationList)
+                .historyPropertyConfigurationList(historyPropertyConfigurationList)
+                .readOnly(registryOverrideConfiguration.isReadOnly())
+                .creatable(registryOverrideConfiguration.isCreatable())
+                .updateable(registryOverrideConfiguration.isUpdateable())
+                .deletable(registryOverrideConfiguration.isDeletable())
+                .isHistoryAvailable(isHistoryAvailable)
+                .isIdentifierAssigned(managedTypeWrapper.isIdentifierAssigned())
+                .isIdClassIdentity(managedTypeWrapper.isIdClassIdentifier())
+                .isEmbeddedIdentity(managedTypeWrapper.isEmbeddedIdentifier())
+                .idClassPropertyNameList(managedTypeWrapper.getIdClassPropertyNameList())
+                .build();
+        }
+
+        private List<RegistryPropertyConfiguration> resolveRegistryPropertyListForType(ManagedTypeWrapper managedTypeWrapper, RegistryOverrideConfiguration registryOverrideConfiguration) {
+            Predicate<String> isIdAttributePredicate = attributeName -> attributeName.equals(managedTypeWrapper.getIdAttributeName())
+                || managedTypeWrapper.getIdClassPropertyNameList().contains(attributeName);
+
+            return resolveManagedTypePropertyList(
+                managedTypeWrapper.getIdentifiableType(), managedTypeWrapper.getIdentifiableType().getJavaType(), null,
+                isIdAttributePredicate, !managedTypeWrapper.isIdentifierAssigned(), registryOverrideConfiguration
+            );
+        }
+
+        private List<RegistryPropertyConfiguration> resolverEmbeddedIdPropertyConfigurationList(ManagedTypeWrapper managedTypeWrapper, RegistryOverrideConfiguration registryOverrideConfiguration) {
+            if (!managedTypeWrapper.isEmbeddedIdentifier()) {
+                return Collections.emptyList();
             }
 
-            String attributeName = prefix == null ? attribute.getName() : String.format(RegistryConfigurationConstants.REGISTRY_PROPERTY_PREFIX_FORMAT, prefix, attribute.getName());
-            Class<?> attributeType = attribute.getJavaType();
-
-            boolean isIdAttribute = isIdAttributePredicate.test(attributeName);
-            boolean isSingularAssociation = attribute.isAssociation() && attribute instanceof SingularAttribute;
-            Class<?> singularAssociationReferencedClass = isSingularAssociation ? resolveSingularAssociationReferencedClass(attribute) : null;
-
-            boolean isReadOnly = isIdAttribute ? isIdReadOnly : readOnlyPropertyList.contains(attributeName) || readOnlyOverridePropertyList.contains(attributeName);
-            boolean isSortable = !nonSortablePropertyList.contains(attributeName);
-            boolean isSearchable = !nonSearchablePropertyList.contains(attributeName);
-
-            RegistryPropertyConfiguration registryPropertyConfiguration = resolveRegistryPropertyConfiguration(
-                entityType.getName(), attributeType, attributeName, isIdAttribute, isSingularAssociation,
-                singularAssociationReferencedClass, isReadOnly, isSortable, isSearchable
+            return resolveManagedTypePropertyList(
+                managedTypeWrapper.getEmbeddableIdType(), managedTypeWrapper.getIdentifiableType().getJavaType(), managedTypeWrapper.getIdAttributeName(),
+                attribute -> false, true, registryOverrideConfiguration
             );
-
-            registryPropertyConfigurationList.add(registryPropertyConfiguration);
-
-        });
-
-        return registryPropertyConfigurationList;
-    }
-
-    private List<RegistryPropertyConfiguration> resolveHistoryPropertyList(RegistryHistoryConfigurationHolder registryHistoryConfiguration) {
-        List<PropertyWithType> historyPropertyList = new ArrayList<>();
-
-        historyPropertyList.add(registryHistoryConfiguration.getRevisionNumberProperty());
-        historyPropertyList.add(registryHistoryConfiguration.getRevisionTimestampProperty());
-        historyPropertyList.add(registryHistoryConfiguration.getRevisionTypeProperty());
-        historyPropertyList.addAll(registryHistoryConfiguration.getRevisionAdditionalPropertyList());
-
-        return historyPropertyList.stream()
-            .map(propertyWithType -> resolveRegistryPropertyConfiguration(
-                    RegistryConfigurationConstants.REGISTRY_REVISION_ENTITY_PREFIX, propertyWithType.getType(), propertyWithType.getName(), false, false,
-                    null, true, true, false
-                )
-            )
-            .sorted(new RegistryPropertyComparator(registryHistoryConfiguration.getPropertyDisplayList()))
-            .collect(Collectors.toList());
-    }
-
-    private RegistryPropertyConfiguration resolveRegistryPropertyConfiguration(String entityTypePrefix, Class<?> attributeType, String attributeName, boolean isIdAttribute,
-                                                                               boolean isSingularAssociation, Class<?> singularAssociationReferencedClass, boolean isReadOnly,
-                                                                               boolean isSortable, boolean isSearchable) {
-        String javascriptType = javaToJavascriptTypeConversionService.convert(attributeType);
-        boolean isDecimal = isDecimal(attributeType);
-
-        String attributeDisplayName = convertToDisplayValue(attributeName);
-        String formLabel = formLabel(entityTypePrefix, attributeType, attributeName, attributeDisplayName);
-        String columnHeader = columnHeader(entityTypePrefix, attributeType, attributeName, attributeDisplayName);
-
-        return RegistryPropertyConfiguration.builder()
-            .name(attributeName)
-            .originalType(attributeType.getName())
-            .javascriptType(javascriptType)
-            .isDecimal(isDecimal)
-            .isSingularAssociation(isSingularAssociation)
-            .singularAssociationReferencedClass(Optional.ofNullable(singularAssociationReferencedClass).map(Class::getName).orElse(null))
-            .isId(isIdAttribute)
-            .formLabel(formLabel)
-            .columnHeader(columnHeader)
-            .editable(!isReadOnly)
-            .searchable(isSearchable)
-            .sortable(isSortable)
-            .build();
-    }
-
-    private Class<?> resolveSingularAssociationReferencedClass(Attribute<?, ?> attribute) {
-        return ((ManagedType<?>) ((SingularAttribute<?, ?>) attribute).getType()).getJavaType();
-    }
-
-    private String groupDisplayLabel(String groupId) {
-        String[] groupMessageCodeList = { String.format(RegistryConfigurationConstants.REGISTRY_GROUP_DISPLAY_LABEL_FORMAT, groupId) };
-        DefaultMessageSourceResolvable messageSourceResolvable = new DefaultMessageSourceResolvable(groupMessageCodeList, groupId);
-
-        return messageSource.getMessage(messageSourceResolvable, LocaleContextHolder.getLocale());
-    }
-
-    private String registryDisplayLabel(Class<?> entityType) {
-        String[] groupMessageCodeList = { String.format(RegistryConfigurationConstants.REGISTRY_NAME_DISPLAY_LABEL_FORMAT, entityType.getName()) };
-        DefaultMessageSourceResolvable messageSourceResolvable = new DefaultMessageSourceResolvable(groupMessageCodeList, entityType.getSimpleName());
-
-        return messageSource.getMessage(messageSourceResolvable, LocaleContextHolder.getLocale());
-    }
-
-    private String formLabel(String entityTypePrefix, Class<?> attributeType, String attributeName, String attributeDisplayName) {
-        String[] messageCodeList = labelMessageCodeList(entityTypePrefix, attributeType, attributeName).toArray(new String[0]);
-        DefaultMessageSourceResolvable messageSourceResolvable = new DefaultMessageSourceResolvable(messageCodeList, attributeDisplayName);
-
-        return messageSource.getMessage(messageSourceResolvable, LocaleContextHolder.getLocale());
-    }
-
-    private String columnHeader(String entityTypePrefix, Class<?> attributeType, String attributeName, String attributeDisplayName) {
-        List<String> headerMessageCodeList = new ArrayList<>();
-
-        headerMessageCodeList.add(String.format(RegistryConfigurationConstants.REGISTRY_COLUMN_HEADER_FORMAT, entityTypePrefix, attributeName));
-        headerMessageCodeList.addAll(labelMessageCodeList(entityTypePrefix, attributeType, attributeName));
-
-        DefaultMessageSourceResolvable messageSourceResolvable = new DefaultMessageSourceResolvable(headerMessageCodeList.toArray(new String[0]), attributeDisplayName);
-
-        return messageSource.getMessage(messageSourceResolvable, LocaleContextHolder.getLocale());
-    }
-
-    private List<String> labelMessageCodeList(String entityTypePrefix, Class<?> attributeType, String attributeName) {
-        return Arrays.asList(
-            String.format(RegistryConfigurationConstants.REGISTRY_FIELD_DISPLAY_LABEL_FORMAT, entityTypePrefix, attributeName),
-            String.format(RegistryConfigurationConstants.REGISTRY_FIELD_DISPLAY_LABEL_FORMAT, attributeName, attributeType.getName()),
-            String.format(RegistryConfigurationConstants.REGISTRY_FIELD_DISPLAY_LABEL_SHORT_FORMAT, attributeType.getName())
-        );
-    }
-
-    private boolean shouldSkipAttribute(List<String> entityIgnoredPropertyList, Attribute<?, ?> attribute) {
-        return attribute.isCollection() || entityIgnoredPropertyList.contains(attribute.getName());
-    }
-
-    private boolean isAudited(Class<?> entityType) {
-        return AnnotationUtil.isAnnotationPresent(entityType, RegistryEnversConstants.ENVERS_AUDITED_ANNOTATION);
-    }
-
-    private RegistryOverrideConfiguration resolveRegistryOverrideConfiguration(Class<?> type, Map<Class<?>, RegistryOverrideConfiguration> registryOverrideConfigurationMap) {
-        if (registryOverrideConfigurationMap == null || registryOverrideConfigurationMap.get(type) == null) {
-            return RegistryOverrideConfiguration.defaultConfiguration();
         }
 
-        return registryOverrideConfigurationMap.get(type);
+        private List<RegistryPropertyConfiguration> resolveManagedTypePropertyList(ManagedType<?> managedType, Class<?> entityType, String prefix, Predicate<String> isIdAttributePredicate,
+                                                                                   boolean isIdReadOnly, RegistryOverrideConfiguration registryOverrideConfiguration) {
+            List<String> ignoredPropertyList = Optional.ofNullable(registryOverrideConfiguration.getIgnoredPropertyList()).orElse(Collections.emptyList());
+            List<String> readOnlyOverridePropertyList = Optional.ofNullable(registryOverrideConfiguration.getNonEditablePropertyList()).orElse(Collections.emptyList());
+            List<String> nonSortablePropertyList = Optional.ofNullable(registryOverrideConfiguration.getNonSortablePropertyList()).orElse(Collections.emptyList());
+            List<String> nonSearchablePropertyList = Optional.ofNullable(registryOverrideConfiguration.getNonSearchablePropertyList()).orElse(Collections.emptyList());
+
+            List<RegistryPropertyConfiguration> registryPropertyConfigurationList = new ArrayList<>();
+
+            managedType.getAttributes().forEach(attribute -> {
+                if (shouldSkipAttribute(ignoredPropertyList, attribute)) {
+                    return;
+                }
+
+                String attributeName = prefix == null ? attribute.getName() : String.format(RegistryConfigurationConstants.REGISTRY_PROPERTY_PREFIX_FORMAT, prefix, attribute.getName());
+                Class<?> attributeType = attribute.getJavaType();
+
+                boolean isIdAttribute = isIdAttributePredicate.test(attributeName);
+                boolean isSingularAssociation = attribute.isAssociation() && attribute instanceof SingularAttribute;
+                Class<?> singularAssociationReferencedClass = isSingularAssociation ? resolveSingularAssociationReferencedClass(attribute) : null;
+
+                boolean isReadOnly = isIdAttribute ? isIdReadOnly : readOnlyPropertyList.contains(attributeName) || readOnlyOverridePropertyList.contains(attributeName);
+                boolean isSortable = !nonSortablePropertyList.contains(attributeName);
+                boolean isSearchable = !nonSearchablePropertyList.contains(attributeName);
+
+                RegistryPropertyConfiguration registryPropertyConfiguration = resolveRegistryPropertyConfiguration(
+                    entityType.getName(), attributeType, attributeName, isIdAttribute, isSingularAssociation,
+                    singularAssociationReferencedClass, isReadOnly, isSortable, isSearchable
+                );
+
+                registryPropertyConfigurationList.add(registryPropertyConfiguration);
+
+            });
+
+            return registryPropertyConfigurationList;
+        }
+
+        private List<RegistryPropertyConfiguration> resolveHistoryPropertyList(RegistryHistoryConfigurationHolder registryHistoryConfiguration) {
+            List<PropertyWithType> historyPropertyList = new ArrayList<>();
+
+            historyPropertyList.add(registryHistoryConfiguration.getRevisionNumberProperty());
+            historyPropertyList.add(registryHistoryConfiguration.getRevisionTimestampProperty());
+            historyPropertyList.add(registryHistoryConfiguration.getRevisionTypeProperty());
+            historyPropertyList.addAll(registryHistoryConfiguration.getRevisionAdditionalPropertyList());
+
+            return historyPropertyList.stream()
+                .map(propertyWithType -> resolveRegistryPropertyConfiguration(
+                        RegistryConfigurationConstants.REGISTRY_REVISION_ENTITY_PREFIX, propertyWithType.getType(), propertyWithType.getName(), false, false,
+                        null, true, true, false
+                    )
+                )
+                .sorted(new RegistryPropertyComparator(registryHistoryConfiguration.getPropertyDisplayList()))
+                .collect(Collectors.toList());
+        }
+
+        private RegistryPropertyConfiguration resolveRegistryPropertyConfiguration(String entityTypePrefix, Class<?> attributeType, String attributeName, boolean isIdAttribute,
+                                                                                   boolean isSingularAssociation, Class<?> singularAssociationReferencedClass, boolean isReadOnly,
+                                                                                   boolean isSortable, boolean isSearchable) {
+            String javascriptType = javaToJavascriptTypeConversionService.convert(attributeType);
+            boolean isDecimal = isDecimal(attributeType);
+
+            String attributeDisplayName = convertToDisplayValue(attributeName);
+            String formLabel = formLabel(entityTypePrefix, attributeType, attributeName, attributeDisplayName);
+            String columnHeader = columnHeader(entityTypePrefix, attributeType, attributeName, attributeDisplayName);
+
+            return RegistryPropertyConfiguration.builder()
+                .name(attributeName)
+                .originalType(attributeType.getName())
+                .javascriptType(javascriptType)
+                .isDecimal(isDecimal)
+                .isSingularAssociation(isSingularAssociation)
+                .singularAssociationReferencedClass(Optional.ofNullable(singularAssociationReferencedClass).map(Class::getName).orElse(null))
+                .isId(isIdAttribute)
+                .formLabel(formLabel)
+                .columnHeader(columnHeader)
+                .editable(!isReadOnly)
+                .searchable(isSearchable)
+                .sortable(isSortable)
+                .build();
+        }
+
+        private Class<?> resolveSingularAssociationReferencedClass(Attribute<?, ?> attribute) {
+            return ((ManagedType<?>) ((SingularAttribute<?, ?>) attribute).getType()).getJavaType();
+        }
+
+        private String groupDisplayLabel(String groupId) {
+            String[] groupMessageCodeList = { String.format(RegistryConfigurationConstants.REGISTRY_GROUP_DISPLAY_LABEL_FORMAT, groupId) };
+            DefaultMessageSourceResolvable messageSourceResolvable = new DefaultMessageSourceResolvable(groupMessageCodeList, groupId);
+
+            return messageSource.getMessage(messageSourceResolvable, LocaleContextHolder.getLocale());
+        }
+
+        private String registryDisplayLabel(Class<?> entityType) {
+            String[] groupMessageCodeList = { String.format(RegistryConfigurationConstants.REGISTRY_NAME_DISPLAY_LABEL_FORMAT, entityType.getName()) };
+            DefaultMessageSourceResolvable messageSourceResolvable = new DefaultMessageSourceResolvable(groupMessageCodeList, entityType.getSimpleName());
+
+            return messageSource.getMessage(messageSourceResolvable, LocaleContextHolder.getLocale());
+        }
+
+        private String formLabel(String entityTypePrefix, Class<?> attributeType, String attributeName, String attributeDisplayName) {
+            String[] messageCodeList = labelMessageCodeList(entityTypePrefix, attributeType, attributeName).toArray(new String[0]);
+            DefaultMessageSourceResolvable messageSourceResolvable = new DefaultMessageSourceResolvable(messageCodeList, attributeDisplayName);
+
+            return messageSource.getMessage(messageSourceResolvable, LocaleContextHolder.getLocale());
+        }
+
+        private String columnHeader(String entityTypePrefix, Class<?> attributeType, String attributeName, String attributeDisplayName) {
+            List<String> headerMessageCodeList = new ArrayList<>();
+
+            headerMessageCodeList.add(String.format(RegistryConfigurationConstants.REGISTRY_COLUMN_HEADER_FORMAT, entityTypePrefix, attributeName));
+            headerMessageCodeList.addAll(labelMessageCodeList(entityTypePrefix, attributeType, attributeName));
+
+            DefaultMessageSourceResolvable messageSourceResolvable = new DefaultMessageSourceResolvable(headerMessageCodeList.toArray(new String[0]), attributeDisplayName);
+
+            return messageSource.getMessage(messageSourceResolvable, LocaleContextHolder.getLocale());
+        }
+
+        private List<String> labelMessageCodeList(String entityTypePrefix, Class<?> attributeType, String attributeName) {
+            return Arrays.asList(
+                String.format(RegistryConfigurationConstants.REGISTRY_FIELD_DISPLAY_LABEL_FORMAT, entityTypePrefix, attributeName),
+                String.format(RegistryConfigurationConstants.REGISTRY_FIELD_DISPLAY_LABEL_FORMAT, attributeName, attributeType.getName()),
+                String.format(RegistryConfigurationConstants.REGISTRY_FIELD_DISPLAY_LABEL_SHORT_FORMAT, attributeType.getName())
+            );
+        }
+
+        private boolean shouldSkipAttribute(List<String> entityIgnoredPropertyList, Attribute<?, ?> attribute) {
+            return attribute.isCollection() || entityIgnoredPropertyList.contains(attribute.getName());
+        }
+
+        private boolean isAudited(Class<?> entityType) {
+            return AnnotationUtil.isAnnotationPresent(entityType, RegistryEnversConstants.ENVERS_AUDITED_ANNOTATION);
+        }
+
+        private RegistryOverrideConfiguration resolveRegistryOverrideConfiguration(Class<?> type, Map<Class<?>, RegistryOverrideConfiguration> registryOverrideConfigurationMap) {
+            if (registryOverrideConfigurationMap == null || registryOverrideConfigurationMap.get(type) == null) {
+                return RegistryOverrideConfiguration.defaultConfiguration();
+            }
+
+            return registryOverrideConfigurationMap.get(type);
+        }
+
+        private String convertToDisplayValue(String attributeName) {
+            List<String> attributeWordList = Arrays.stream(StringUtils.splitByCharacterTypeCamelCase(attributeName))
+                .map(value -> value.trim().toLowerCase(Locale.ROOT))
+                .filter(value -> !RegistryCoreConstants.DOT.equals(value))
+                .collect(Collectors.toList());
+
+            return StringUtils.capitalize(String.join(RegistryCoreConstants.SPACE, attributeWordList));
+        }
+
+        private boolean isDecimal(Class<?> type) {
+            return type.isAssignableFrom(BigDecimal.class) || type.isAssignableFrom(Float.class) || type.isAssignableFrom(Double.class);
+        }
+
     }
-
-    private String convertToDisplayValue(String attributeName) {
-        List<String> attributeWordList = Arrays.stream(StringUtils.splitByCharacterTypeCamelCase(attributeName))
-            .map(value -> value.trim().toLowerCase(Locale.ROOT))
-            .filter(value -> !RegistryCoreConstants.DOT.equals(value))
-            .collect(Collectors.toList());
-
-        return StringUtils.capitalize(String.join(RegistryCoreConstants.SPACE, attributeWordList));
-    }
-
-    private boolean isDecimal(Class<?> type) {
-        return type.isAssignableFrom(BigDecimal.class) || type.isAssignableFrom(Float.class) || type.isAssignableFrom(Double.class);
-    }
-
-}

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/service/DefaultRegistryDataServiceTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/service/DefaultRegistryDataServiceTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createAndSaveRegistryTestEmbeddedUserGroup;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createBulkListRegistryRequest;
+import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createEmbeddedIdSearchRequest;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createListRegistryRequest;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createRegistryTestEmbeddedUserGroup;
 import static net.croz.nrich.registry.data.testutil.RegistryDataGeneratingUtil.createRegistryTestEmbeddedUserGroupId;
@@ -394,5 +395,19 @@ class DefaultRegistryDataServiceTest {
         assertThat(loaded.getAge()).isEqualTo(50);
         assertThat(loaded.getName()).isEqualTo("name 1");
         assertThat(loaded.getParent()).isNotNull();
+    }
+
+    @Test
+    void shouldSearchByEmbeddedId() {
+        // given
+        createAndSaveRegistryTestEmbeddedUserGroup(entityManager);
+        RegistryTestEmbeddedUserGroup entity = createAndSaveRegistryTestEmbeddedUserGroup(entityManager);
+        ListRegistryRequest request = createEmbeddedIdSearchRequest(entity);
+
+        // when
+        Page<RegistryTestEmbeddedUserGroup> result = registryDataService.list(request);
+
+        // then
+        assertThat(result).hasSize(1);
     }
 }

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataGeneratingUtil.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataGeneratingUtil.java
@@ -346,6 +346,22 @@ public final class RegistryDataGeneratingUtil {
         return request;
     }
 
+    public static ListRegistryRequest createEmbeddedIdSearchRequest(RegistryTestEmbeddedUserGroup entity) {
+        SearchParameter searchParameter = new SearchParameter();
+
+        searchParameter.setPropertyNameList(List.of("userGroupId.user"));
+        searchParameter.setQuery(entity.getUserGroupId().getGroup().getId().toString());
+
+        ListRegistryRequest request = new ListRegistryRequest();
+
+        request.setClassFullName(RegistryTestEmbeddedUserGroup.class.getName());
+        request.setPageNumber(0);
+        request.setPageSize(10);
+        request.setSearchParameter(searchParameter);
+
+        return request;
+    }
+
     private static RegistryTestEntity createRegistryTestEntity(String name, Integer age, RegistryTestEntity parent) {
         RegistryTestEntity entity = new RegistryTestEntity();
 

--- a/nrich-search/src/test/java/net/croz/nrich/search/converter/DefaultStringToEntityPropertyMapConverterTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/converter/DefaultStringToEntityPropertyMapConverterTest.java
@@ -107,6 +107,19 @@ class DefaultStringToEntityPropertyMapConverterTest {
         assertThat(result).containsKeys(propertyToSearchList.toArray(new String[0])).containsValue(dateOf(value));
     }
 
+    @Test
+    void shouldSupportSearchingAssociationsById() {
+        // given
+        String value = "1";
+        List<String> propertyToSearchList = List.of("nestedEntity", "nestedEntityList");
+
+        // when
+        Map<String, Object> result = stringToEntityPropertyMapConverter.convert(value, propertyToSearchList, managedTypeOfTestEntity(), PROPERTY_CONFIGURATION);
+
+        // then
+        assertThat(result).containsKeys("nestedEntity.id", "nestedEntityList.id").containsValue(Long.parseLong(value));
+    }
+
     private ManagedType<?> managedTypeOfTestEntity() {
         return entityManager.getMetamodel().managedType((Class<?>) DefaultStringToEntityPropertyMapConverterTestEntity.class);
     }

--- a/nrich-search/src/test/java/net/croz/nrich/search/converter/stub/DefaultStringToEntityPropertyMapConverterTestEntity.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/converter/stub/DefaultStringToEntityPropertyMapConverterTestEntity.java
@@ -22,8 +22,10 @@ import lombok.Setter;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import java.util.Date;
+import java.util.List;
 
 @Setter
 @Getter
@@ -41,5 +43,8 @@ public class DefaultStringToEntityPropertyMapConverterTestEntity {
 
     @OneToOne
     private DefaultStringToEntityPropertyMapConverterTestNestedEntity nestedEntity;
+
+    @OneToMany
+    private List<DefaultStringToEntityPropertyMapConverterTestNestedEntity> nestedEntityList;
 
 }


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.4.1
* Module:
nrich-search, nrich-registry
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Fallback to searching by association id when association name has been sent as property name

### Details

Fallback to searching by association id when association name has been sent as property name

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
