### PR TITLE
Switch to a user token in the publish plugin authentication configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,8 @@ jobs:
         with:
           arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository --info -Dorg.gradle.internal.http.socketTimeout=180000 -Dorg.gradle.internal.http.connectionTimeout=180000
         env:
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_TOKEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
+          SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,8 @@ nexusPublishing {
       nexusUrl = uri("$sonatypeNexusUrl/service/local/")
       snapshotRepositoryUrl = uri("$sonatypeNexusUrl/content/repositories/snapshots/")
 
-      username = sonatypeUsername
-      password = System.getenv("SONATYPE_PASSWORD")
+      username = System.getenv("SONATYPE_TOKEN_USERNAME")
+      password = System.getenv("SONATYPE_TOKEN_PASSWORD")
 
       // Specifying the configuration property explicitly rather than relying on the API call
       // is considered a performance optimization and can reduce execution time by several seconds

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,3 @@ projectRepositoryUrl=https://github.com/croz-ltd/nrich
 
 # Maven Central
 sonatypeNexusUrl=https://s01.oss.sonatype.org
-sonatypeUsername=nrich


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version: 2.4.1
* Module: project

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Switch to a user token in the publish plugin authentication configuration.

### Details

This is needed because of changes in Maven Central authentication.
Using Nexus UI username and password login in the publish plugin configuration is no longer supported.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] ~~My change requires a change to the documentation~~
- [ ] ~~I have updated the documentation accordingly~~
- [ ] ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
