### PR TITLE
Remove join fetches from entity find query

### DIFF
--- a/nrich-registry/src/main/java/net/croz/nrich/registry/core/constants/RegistryQueryConstants.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/core/constants/RegistryQueryConstants.java
@@ -31,8 +31,6 @@ public final class RegistryQueryConstants {
 
     public static final String FIND_QUERY_SEPARATOR = " and ";
 
-    public static final String FIND_QUERY_JOIN_FETCH = " left join fetch " + ENTITY_ALIAS + ".%s ";
-
     private RegistryQueryConstants() {
     }
 }

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/core/service/EntityManagerRegistryEntityFinderService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/core/service/EntityManagerRegistryEntityFinderService.java
@@ -20,7 +20,6 @@ package net.croz.nrich.registry.core.service;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.croz.nrich.registry.api.core.service.RegistryEntityFinderService;
-import net.croz.nrich.registry.core.constants.RegistryCoreConstants;
 import net.croz.nrich.registry.core.constants.RegistryQueryConstants;
 import net.croz.nrich.registry.core.support.ManagedTypeWrapper;
 import org.modelmapper.ModelMapper;
@@ -49,13 +48,8 @@ public class EntityManagerRegistryEntityFinderService implements RegistryEntityF
     public <T> T findEntityInstance(Class<T> type, Object id) {
         QueryCondition queryCondition = queryWherePartWithParameterMap(type, id, true);
 
-        String joinFetchQueryPart = classNameManagedTypeWrapperMap.get(type.getName()).getSingularAssociationList().stream()
-            .map(attribute -> String.format(RegistryQueryConstants.FIND_QUERY_JOIN_FETCH, attribute.getPath()))
-            .collect(Collectors.joining(RegistryCoreConstants.SPACE));
-
         String entityWithAlias = String.format(RegistryQueryConstants.PROPERTY_SPACE_FORMAT, type.getName(), RegistryQueryConstants.ENTITY_ALIAS);
-        String querySelectPart = String.format(RegistryQueryConstants.PROPERTY_SPACE_FORMAT, entityWithAlias, joinFetchQueryPart.trim());
-        String fullQuery = String.format(RegistryQueryConstants.FIND_QUERY, querySelectPart, queryCondition.wherePart);
+        String fullQuery = String.format(RegistryQueryConstants.FIND_QUERY, entityWithAlias, queryCondition.wherePart);
 
         @SuppressWarnings("unchecked")
         TypedQuery<T> query = (TypedQuery<T>) entityManager.createQuery(fullQuery);


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.5.1
* Module:
nrich-registry
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Removed join fetches from the entity find query since it causes issues with multiple associations and is unnecessary for the query.

### Details

Removed join fetches from the entity find query since it causes issues with multiple associations and is unnecessary for the query.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
