### PR TITLE
Add default values to registry override

### DIFF
--- a/nrich-registry-api/src/main/java/net/croz/nrich/registry/api/core/model/RegistryOverrideConfiguration.java
+++ b/nrich-registry-api/src/main/java/net/croz/nrich/registry/api/core/model/RegistryOverrideConfiguration.java
@@ -17,7 +17,6 @@
 
 package net.croz.nrich.registry.api.core.model;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -29,71 +28,56 @@ import java.util.List;
  */
 @Setter
 @Getter
-@Builder
 public class RegistryOverrideConfiguration {
 
     /**
      * Whether this entity is read only.
      */
-    private boolean readOnly;
+    private boolean readOnly = false;
 
     /**
      * Whether new instances of this entity can be created.
      */
-    private boolean creatable;
+    private boolean creatable = true;
 
     /**
      * Whether this entity can be updated.
      */
-    private boolean updateable;
+    private boolean updateable = true;
 
     /**
      * Whether this entity can be deleted.
      */
-    private boolean deletable;
+    private boolean deletable = true;
 
     /**
      * Whether history for this entity is available.
      */
-    private boolean isHistoryAvailable;
+    private boolean isHistoryAvailable = false;
 
     /**
      * List of properties that should be excluded from configuration.
      */
-    private List<String> ignoredPropertyList;
+    private List<String> ignoredPropertyList = Collections.emptyList();
 
     /**
      * Order of properties.
      */
-    private List<String> propertyDisplayOrderList;
+    private List<String> propertyDisplayOrderList = Collections.emptyList();
 
     /**
      * List of non-editable properties.
      */
-    private List<String> nonEditablePropertyList;
+    private List<String> nonEditablePropertyList = Collections.emptyList();
 
     /**
      * List of non sortable properties.
      */
-    private List<String> nonSortablePropertyList;
+    private List<String> nonSortablePropertyList = Collections.emptyList();
 
     /**
      * List of non-searchable properties.
      */
-    private List<String> nonSearchablePropertyList;
+    private List<String> nonSearchablePropertyList = Collections.emptyList();
 
-    public static RegistryOverrideConfiguration defaultConfiguration() {
-        return RegistryOverrideConfiguration.builder()
-            .readOnly(false)
-            .creatable(true)
-            .updateable(true)
-            .deletable(true)
-            .isHistoryAvailable(false)
-            .ignoredPropertyList(Collections.emptyList())
-            .propertyDisplayOrderList(Collections.emptyList())
-            .nonEditablePropertyList(Collections.emptyList())
-            .nonSortablePropertyList(Collections.emptyList())
-            .nonSearchablePropertyList(Collections.emptyList())
-            .build();
-    }
 }

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/configuration/service/DefaultRegistryConfigurationService.java
@@ -284,7 +284,7 @@
 
         private RegistryOverrideConfiguration resolveRegistryOverrideConfiguration(Class<?> type, Map<Class<?>, RegistryOverrideConfiguration> registryOverrideConfigurationMap) {
             if (registryOverrideConfigurationMap == null || registryOverrideConfigurationMap.get(type) == null) {
-                return RegistryOverrideConfiguration.defaultConfiguration();
+                return new RegistryOverrideConfiguration();
             }
 
             return registryOverrideConfigurationMap.get(type);

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/security/interceptor/RegistryConfigurationUpdateInterceptor.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/security/interceptor/RegistryConfigurationUpdateInterceptor.java
@@ -56,7 +56,7 @@ public class RegistryConfigurationUpdateInterceptor extends BaseRegistryDataInte
 
     private RegistryOverrideConfiguration resolveConfiguration(String classFullName) {
         if (registryOverrideConfigurationMap.get(classFullName) == null) {
-            return RegistryOverrideConfiguration.defaultConfiguration();
+            return new RegistryOverrideConfiguration();
         }
 
         return registryOverrideConfigurationMap.get(classFullName);
@@ -71,9 +71,9 @@ public class RegistryConfigurationUpdateInterceptor extends BaseRegistryDataInte
             .collect(Collectors.toMap(entry -> entry.getKey().getName(), Map.Entry::getValue));
     }
 
-    private void verifyRegistryOperation(String registryClassName, boolean isAllowed) {
-        if (isAllowed) {
-            throw new RegistryUpdateNotAllowedException(String.format("Trying to update registry: %s that is not updatable", registryClassName));
+    private void verifyRegistryOperation(String registryClassName, boolean isNotAllowed) {
+        if (isNotAllowed) {
+            throw new RegistryUpdateNotAllowedException(String.format("Trying to edit registry: %s that is not editable", registryClassName));
         }
     }
 }

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/RegistryTestConfiguration.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/RegistryTestConfiguration.java
@@ -309,7 +309,7 @@ public class RegistryTestConfiguration {
     }
 
     private List<RegistryOverrideConfigurationHolder> createRegistryOverrideConfigurationList() {
-        RegistryOverrideConfiguration configurationEntityConfiguration = RegistryOverrideConfiguration.defaultConfiguration();
+        RegistryOverrideConfiguration configurationEntityConfiguration = new RegistryOverrideConfiguration();
 
         configurationEntityConfiguration.setPropertyDisplayOrderList(Arrays.asList("name", "id", "nonEditableProperty", "floatNumber", "doubleNumber"));
         configurationEntityConfiguration.setIgnoredPropertyList(Collections.singletonList("skippedProperty"));
@@ -320,13 +320,13 @@ public class RegistryTestConfiguration {
         RegistryOverrideConfigurationHolder configurationEntityConfigurationHolder = RegistryOverrideConfigurationHolder.builder()
             .type(RegistryConfigurationTestEntity.class).overrideConfiguration(configurationEntityConfiguration).build();
 
-        RegistryOverrideConfiguration interceptorTestEntityConfiguration = RegistryOverrideConfiguration.defaultConfiguration();
+        RegistryOverrideConfiguration interceptorTestEntityConfiguration = new RegistryOverrideConfiguration();
         interceptorTestEntityConfiguration.setReadOnly(true);
 
         RegistryOverrideConfigurationHolder interceptorTestEntityConfigurationHolder = RegistryOverrideConfigurationHolder.builder()
             .type(RegistryConfigurationUpdateInterceptorTestEntity.class).overrideConfiguration(interceptorTestEntityConfiguration).build();
 
-        RegistryOverrideConfiguration InterceptorTestNonEntityNonModifiableConfiguration = RegistryOverrideConfiguration.defaultConfiguration();
+        RegistryOverrideConfiguration InterceptorTestNonEntityNonModifiableConfiguration = new RegistryOverrideConfiguration();
 
         InterceptorTestNonEntityNonModifiableConfiguration.setDeletable(false);
         InterceptorTestNonEntityNonModifiableConfiguration.setUpdateable(false);
@@ -341,7 +341,7 @@ public class RegistryTestConfiguration {
         RegistryOverrideConfigurationHolder searchConfigurationHolder = RegistryOverrideConfigurationHolder.builder()
             .type(RegistryTestEntityWithOverriddenSearchConfiguration.class).overrideSearchConfiguration(searchConfiguration).build();
 
-        RegistryOverrideConfiguration embeddedEntityOverrideConfiguration = RegistryOverrideConfiguration.defaultConfiguration();
+        RegistryOverrideConfiguration embeddedEntityOverrideConfiguration = new RegistryOverrideConfiguration();
 
         embeddedEntityOverrideConfiguration.setPropertyDisplayOrderList(List.of("id.secondId", "id.firstId"));
 

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/core/testutil/RegistryConfigurationGeneratingUtil.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/core/testutil/RegistryConfigurationGeneratingUtil.java
@@ -71,7 +71,7 @@ public final class RegistryConfigurationGeneratingUtil {
     }
 
     public static List<RegistryOverrideConfigurationHolder> createRegistryOverrideConfigurationList() {
-        RegistryOverrideConfiguration overrideConfiguration = RegistryOverrideConfiguration.defaultConfiguration();
+        RegistryOverrideConfiguration overrideConfiguration = new RegistryOverrideConfiguration();
 
         RegistryOverrideConfigurationHolder registryOverrideConfigurationHolder = RegistryOverrideConfigurationHolder.builder()
             .type(RegistryConfigurationRegularTestEntity.class)


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.5.2
* Module:
nrich-registry

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add default values to registry override so user doesn't have to specify all the values when overriding configuration

### Details

Add default values to registry override so user doesn't have to specify all the values when overriding configuration

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
