### PR TITLE
Add support for sorting by subclass properties

### DIFF
--- a/nrich-search/src/main/java/net/croz/nrich/search/support/JpaQueryBuilder.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/support/JpaQueryBuilder.java
@@ -32,7 +32,7 @@ import net.croz.nrich.search.parser.SearchDataParser;
 import net.croz.nrich.search.util.PathResolvingUtil;
 import net.croz.nrich.search.util.ProjectionListResolverUtil;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.repository.query.QueryUtils;
+import org.springframework.data.jpa.repository.query.NrichQueryUtils;
 import org.springframework.data.util.DirectFieldAccessFallbackBeanWrapper;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -101,7 +101,7 @@ public class JpaQueryBuilder<T> {
         query.distinct(searchConfiguration.isDistinct());
 
         if (sort != null && sort.isSorted()) {
-            query.orderBy(QueryUtils.toOrders(sort, root, criteriaBuilder));
+            query.orderBy(NrichQueryUtils.toOrders(sort, root, criteriaBuilder));
         }
 
         return query;

--- a/nrich-search/src/main/java/org/springframework/data/jpa/repository/query/NrichQueryUtils.java
+++ b/nrich-search/src/main/java/org/springframework/data/jpa/repository/query/NrichQueryUtils.java
@@ -1,0 +1,99 @@
+package org.springframework.data.jpa.repository.query;
+
+import org.hibernate.metamodel.model.domain.EntityDomainType;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mapping.PropertyPath;
+import org.springframework.data.mapping.PropertyReferenceException;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.ConcurrentReferenceHashMap;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.metamodel.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adds support for sorting by subclass properties. Although Hibernate supports sorting by subclass properties, Spring will throw an exception.
+ */
+public final class NrichQueryUtils {
+
+    private static final Map<PropertyPathKey, PropertyPath> PROPERTY_PATH_CACHE = new ConcurrentReferenceHashMap<>();
+
+    private NrichQueryUtils() {
+    }
+
+    public static List<Order> toOrders(Sort sort, From<?, ?> from, CriteriaBuilder cb) {
+        if (sort.isUnsorted()) {
+            return Collections.emptyList();
+        }
+
+        Assert.notNull(from, "From must not be null");
+        Assert.notNull(cb, "CriteriaBuilder must not be null");
+
+        List<jakarta.persistence.criteria.Order> orders = new ArrayList<>();
+
+        for (org.springframework.data.domain.Sort.Order order : sort) {
+            orders.add(toJpaOrder(order, from, cb));
+        }
+
+        return orders;
+    }
+
+    private static jakarta.persistence.criteria.Order toJpaOrder(Sort.Order order, From<?, ?> from, CriteriaBuilder cb) {
+        String propertyName = order.getProperty();
+
+        PropertyPath property = PROPERTY_PATH_CACHE.computeIfAbsent(new PropertyPathKey(propertyName, from.getJavaType()), key -> resolvePropertyPath(propertyName, from));
+        Expression<?> expression = QueryUtils.toExpressionRecursively(from, property);
+
+        if (order.isIgnoreCase() && String.class.equals(expression.getJavaType())) {
+            @SuppressWarnings("unchecked")
+            Expression<String> upper = cb.lower((Expression<String>) expression);
+            return order.isAscending() ? cb.asc(upper) : cb.desc(upper);
+        }
+
+        return order.isAscending() ? cb.asc(expression) : cb.desc(expression);
+    }
+
+    private static PropertyPath resolvePropertyPath(String property, From<?, ?> from) {
+        PropertyReferenceException originalException;
+        try {
+            return PropertyPath.from(property, from.getJavaType());
+        }
+        catch (PropertyReferenceException exception) {
+            originalException = exception;
+        }
+
+        List<? extends Class<?>> subtypeList = resolveSubtypeList(from);
+        if (!CollectionUtils.isEmpty(subtypeList)) {
+            for (Class<?> subtype : subtypeList) {
+                try {
+                    return PropertyPath.from(property, subtype);
+                }
+                catch (PropertyReferenceException exception) {
+                    // ignored
+                }
+            }
+        }
+
+        throw originalException;
+    }
+
+    private static List<? extends Class<?>> resolveSubtypeList(From<?, ?> from) {
+        if (from.getModel() instanceof EntityDomainType<?> entityDomainType) {
+            return entityDomainType.getSubTypes().stream()
+                .map(Type::getJavaType)
+                .toList();
+        }
+
+        return Collections.emptyList();
+    }
+
+    record PropertyPathKey(String property, Class<?> type) {
+    }
+}

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/support/JpaQueryBuilderTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/support/JpaQueryBuilderTest.java
@@ -390,6 +390,20 @@ class JpaQueryBuilderTest {
     }
 
     @Test
+    void shouldSortBySubclassProperty() {
+        // given
+        generateTestSubEntityList(entityManager);
+        Map<String, Object> requestMap = Map.of("subName", "subName");
+
+        // when
+        List<TestEntity> results = executeQuery(requestMap, SearchConfiguration.emptyConfiguration(), Sort.by(Sort.Order.desc("subName")));
+
+        // then
+        assertThat(results).isNotEmpty();
+        assertThat(results).extracting("subName").containsExactly("subName2", "subName1", "subName0");
+    }
+
+    @Test
     void shouldSortByJoinedEntity() {
         // given
         TestEntitySearchRequest request = new TestEntitySearchRequest(null);

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/testutil/JpaSearchRepositoryExecutorGeneratingUtil.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/testutil/JpaSearchRepositoryExecutorGeneratingUtil.java
@@ -29,12 +29,10 @@ import net.croz.nrich.search.repository.stub.TestEntityWithCustomId;
 import net.croz.nrich.search.repository.stub.TestEntityWithEmbeddedId;
 import net.croz.nrich.search.repository.stub.TestNestedEntity;
 import net.croz.nrich.search.repository.stub.TestStringSearchEntity;
+import net.croz.nrich.search.repository.stub.TestSubEntity;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.JoinType;
-
-import net.croz.nrich.search.repository.stub.TestSubEntity;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -75,7 +73,7 @@ public final class JpaSearchRepositoryExecutorGeneratingUtil {
     public static List<TestStringSearchEntity> generateListForStringSearch(EntityManager entityManager) {
         LocalDate date = LocalDate.parse("01.01.1970", DateTimeFormatter.ofPattern("dd.MM.yyyy"));
         List<TestStringSearchEntity> testEntityList = IntStream.range(0, 5)
-            .mapToObj(value -> createTestStringSearchEntity("name " + value, 50 + value, date.plus(value, ChronoUnit.DAYS)))
+            .mapToObj(value -> createTestStringSearchEntity("name " + value, 50 + value, date.plusDays(value)))
             .collect(Collectors.toList());
 
         testEntityList.forEach(entityManager::persist);


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.5.4
* Module:
nrich-search
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add support for sorting by subclass properties when going through Spring (Hibernate already supports it but Spring fails with exception)


### Details

Add support for sorting by subclass properties when going through Spring (Hibernate already supports it but Spring fails with exception)

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
