### PR TITLE
Fix issue with collection attributes not being recognized

### DIFF
--- a/nrich-search/src/main/java/net/croz/nrich/search/parser/SearchDataParser.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/parser/SearchDataParser.java
@@ -92,7 +92,7 @@ public class SearchDataParser {
                 }
 
                 // element collections have null managed type but should be treated as plural attributes
-                boolean isCurrentAttributePlural = attributeHolder.isElementCollection() || isPluralAttribute;
+                boolean isCurrentAttributePlural = attributeHolder.isPlural() || attributeHolder.isElementCollection() || isPluralAttribute;
 
                 restrictionList.add(createAttributeRestriction(attributeHolder.getAttribute().getJavaType(), originalFieldName, currentPath, value, isCurrentAttributePlural));
             }

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/support/JpaQueryBuilderTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/support/JpaQueryBuilderTest.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static net.croz.nrich.search.repository.testutil.JpaSearchRepositoryExecutorGeneratingUtil.createTestEntityForCollectionSearch;
 import static net.croz.nrich.search.repository.testutil.JpaSearchRepositoryExecutorGeneratingUtil.createTestEntitySearchRequestJoin;
 import static net.croz.nrich.search.repository.testutil.JpaSearchRepositoryExecutorGeneratingUtil.generateListForSearch;
 import static net.croz.nrich.search.repository.testutil.JpaSearchRepositoryExecutorGeneratingUtil.generateTestEntityWithCustomIdList;
@@ -872,11 +873,28 @@ class JpaQueryBuilderTest {
         assertThat(results).hasSize(1);
     }
 
+    @Test
+    void shouldCountCorrectlyWhenSearchingByCollection() {
+        // given
+        TestEntity entity = createTestEntityForCollectionSearch(entityManager);
+        Map<String, Object> requestMap = Map.of("name", entity.getName(), "collectionEntityList.name", "collection");
+
+        // when
+        Long result = executeCountQuery(requestMap, SearchConfiguration.emptyConfigurationWithDefaultMappingResolve());
+
+        // then
+        assertThat(result).isEqualTo(1L);
+    }
+
     private <P, R> List<P> executeQuery(R request, SearchConfiguration<TestEntity, P, R> searchConfiguration) {
         return executeQuery(request, searchConfiguration, Sort.unsorted());
     }
 
     private <P, R> List<P> executeQuery(R request, SearchConfiguration<TestEntity, P, R> searchConfiguration, Sort sort) {
         return entityManager.createQuery(jpaQueryBuilder.buildQuery(request, searchConfiguration, sort)).getResultList();
+    }
+
+    private <P, R> Long executeCountQuery(R request, SearchConfiguration<TestEntity, P, R> searchConfiguration) {
+        return entityManager.createQuery(jpaQueryBuilder.buildCountQuery(request, searchConfiguration)).getSingleResult();
     }
 }

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/testutil/JpaSearchRepositoryExecutorGeneratingUtil.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/testutil/JpaSearchRepositoryExecutorGeneratingUtil.java
@@ -35,7 +35,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.JoinType;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -135,6 +134,16 @@ public final class JpaSearchRepositoryExecutorGeneratingUtil {
 
             entityManager.persist(entity);
         });
+    }
+
+    public static TestEntity createTestEntityForCollectionSearch(EntityManager entityManager) {
+        TestEntity testEntity = createTestEntity(1, 3);
+
+        testEntity.setName("CollectionSearchEntity");
+
+        entityManager.persist(testEntity);
+
+        return testEntity;
     }
 
     private static TestEntity createTestEntity(Integer value, Integer numberOfCollectionEntities) {


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.6.0
* Module:
nrich-search

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Fix issue with collection attributes not being recognized and using a join instead of exist query by default

### Details

Fix issue with collection attributes not being recognized and using a join instead of exist query by default

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
