### PR TITLE
Avoid NPE in DefaultTransientPropertyResolverService

### DIFF
--- a/nrich-webmvc/src/main/java/net/croz/nrich/webmvc/service/DefaultTransientPropertyResolverService.java
+++ b/nrich-webmvc/src/main/java/net/croz/nrich/webmvc/service/DefaultTransientPropertyResolverService.java
@@ -33,7 +33,7 @@ public class DefaultTransientPropertyResolverService implements TransientPropert
         List<String> transientPropertyList = new ArrayList<>();
         Class<?> currentType = type;
 
-        while (currentType != Object.class) {
+        while (currentType != null && currentType != Object.class) {
             List<String> currentTransientPropertyList = Arrays.stream(currentType.getDeclaredFields())
                 .filter(this::includeField)
                 .map(Field::getName)

--- a/nrich-webmvc/src/test/java/net/croz/nrich/webmvc/service/DefaultTransientPropertyResolverServiceTest.java
+++ b/nrich-webmvc/src/test/java/net/croz/nrich/webmvc/service/DefaultTransientPropertyResolverServiceTest.java
@@ -24,8 +24,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 @SpringJUnitWebConfig(WebmvcTestConfiguration.class)
 class DefaultTransientPropertyResolverServiceTest {
@@ -43,5 +45,14 @@ class DefaultTransientPropertyResolverServiceTest {
 
         // then
         assertThat(resultList).containsExactlyInAnyOrder("value", "anotherValue");
+    }
+
+    @Test
+    void shouldNotFailWhenResolvingTransientPropertyListFromInteface() {
+        // when
+        Throwable thrown = catchThrowable(() -> transientPropertyResolverService.resolveTransientPropertyList(Map.class));
+
+        // then
+        assertThat(thrown).isNull();
     }
 }


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version: 2.7.0
  <!-- released version or snapshot version -->
* Module: nrich-webmvc
  <!-- Please, include name(s) of relevant nrich's module(s). If not related to any specific module, specify "project" instead. -->

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Existing code caused NPE when type did not extend Object class. 
This is the case with interfaces, such as java.util.Map.

### Details

Existing code caused NPE when type did not extend Object class. 
This is the case with interfaces, such as java.util.Map.

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
