### PR TITLE
Add support for ignoring properties when updating registry entites

### DIFF
--- a/nrich-registry-api/build.gradle
+++ b/nrich-registry-api/build.gradle
@@ -7,5 +7,6 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
   compileOnly "org.projectlombok:lombok"
 
+  implementation "org.modelmapper:modelmapper"
   implementation "org.springframework.data:spring-data-commons"
 }

--- a/nrich-registry-api/src/main/java/net/croz/nrich/registry/api/core/customizer/ModelMapperCustomizer.java
+++ b/nrich-registry-api/src/main/java/net/croz/nrich/registry/api/core/customizer/ModelMapperCustomizer.java
@@ -1,0 +1,9 @@
+package net.croz.nrich.registry.api.core.customizer;
+
+import org.modelmapper.ModelMapper;
+
+public interface ModelMapperCustomizer {
+
+    void customize(ModelMapperType type, ModelMapper modelMapper);
+
+}

--- a/nrich-registry-api/src/main/java/net/croz/nrich/registry/api/core/customizer/ModelMapperType.java
+++ b/nrich-registry-api/src/main/java/net/croz/nrich/registry/api/core/customizer/ModelMapperType.java
@@ -1,0 +1,5 @@
+package net.croz.nrich.registry.api.core.customizer;
+
+public enum ModelMapperType {
+    BASE, DATA
+}

--- a/nrich-registry-spring-boot-starter/README.md
+++ b/nrich-registry-spring-boot-starter/README.md
@@ -42,17 +42,18 @@ Note if using `nrich-bom` dependency versions should be omitted.
 
 Configuration is done through a property file, available properties and descriptions are given bellow (all properties are prefixed with nrich.registry which is omitted for readability):
 
-| property                                               | description                                                                                                                | default value                                            |
-|--------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| default-read-only-property-list                        | List of property names that should always be marked as readonly                                                            |                                                          |
-| default-converter-enabled                              | Whether default string to type converter used for converting strings to property values when searching registry is enabled | true                                                     |
-| default-java-to-javascript-converter-enabled           | Whether default Java to Javascript type converter is enabled                                                               | true                                                     |
-| registry-search.date-format-list                       | List of date formats used to convert string to date value                                                                  | dd.MM.yyyy., dd.MM.yyyy.'T'HH:mm, dd.MM.yyyy.'T'HH:mm'Z' |
-| registry-search.decimal-number-format-list             | List of decimal formats used to convert string to decimal value                                                            | #0.00, #0,00                                             |
-| registry-search.boolean-true-regex-pattern             | Regexp pattern that is used to match boolean true values                                                                   | ^(?i)\s*(true&#124;yes&#124;da)\s*$                      |
-| registry-search.boolean-false-regex-pattern            | Regexp pattern that is used to match boolean false values                                                                  | ^(?i)\s*(false&#124;no&#124;ne)\s*$                      |
-| registry-configuration.create-registry-class-mapping   | Optional mapping between registry classname and the class holding validations for registry create method                   |                                                          |
-| registry-configuration.update-registry-class-mapping   | Optional mapping between registry classname and the class holding validations for registry update method                   |                                                          |
+| property                                             | description                                                                                                                | default value                                            |
+|------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| default-read-only-property-list                      | List of property names that should always be marked as readonly                                                            |                                                          |
+| default-converter-enabled                            | Whether default string to type converter used for converting strings to property values when searching registry is enabled | true                                                     |
+| default-java-to-javascript-converter-enabled         | Whether default Java to Javascript type converter is enabled                                                               | true                                                     |
+| registry-model-mapper-customizer-enabled             | Whether default ModelMapper customizer used for skipping ignored properties when updating registry entities is enabled.    | true                                                     |
+| registry-search.date-format-list                     | List of date formats used to convert string to date value                                                                  | dd.MM.yyyy., dd.MM.yyyy.'T'HH:mm, dd.MM.yyyy.'T'HH:mm'Z' |
+| registry-search.decimal-number-format-list           | List of decimal formats used to convert string to decimal value                                                            | #0.00, #0,00                                             |
+| registry-search.boolean-true-regex-pattern           | Regexp pattern that is used to match boolean true values                                                                   | ^(?i)\s*(true&#124;yes&#124;da)\s*$                      |
+| registry-search.boolean-false-regex-pattern          | Regexp pattern that is used to match boolean false values                                                                  | ^(?i)\s*(false&#124;no&#124;ne)\s*$                      |
+| registry-configuration.create-registry-class-mapping | Optional mapping between registry classname and the class holding validations for registry create method                   |                                                          |
+| registry-configuration.update-registry-class-mapping | Optional mapping between registry classname and the class holding validations for registry update method                   |                                                          |
 
 The properties under registry-search are used when converting string received from client to property values that will be used to search registry. For example if a string is sent
 and the property searched by is of type Date, nrich will try to parse string to Date and if parsing succeeds restriction will be added to query and if parsing fails the property will be skipped
@@ -63,14 +64,14 @@ The default configuration values in yaml format for easier modification are give
 ```yaml
 
 nrich.registry:
-  default-read-only-property-list:
-  default-converter-enabled: true
-  default-java-to-javascript-converter-enabled: true
-  registry-search:
-    date-format-list: dd.MM.yyyy., dd.MM.yyyy.'T'HH:mm, dd.MM.yyyy.'T'HH:mm'Z'
-    decimal-number-format-list: #0.00, #0,00
-    boolean-true-regex-pattern: ^(?i)\s*(true|yes|da)\s*$
-    boolean-false-regex-pattern: ^(?i)\s*(false|no|ne)\s*$
+    default-read-only-property-list:
+    default-converter-enabled: true
+    default-java-to-javascript-converter-enabled: true
+    registry-search:
+        date-format-list: dd.MM.yyyy., dd.MM.yyyy.'T'HH:mm, dd.MM.yyyy.'T'HH:mm'Z'
+        decimal-number-format-list: #0.00, #0,00
+        boolean-true-regex-pattern: ^(?i)\s*(true|yes|da)\s*$
+        boolean-false-regex-pattern: ^(?i)\s*(false|no|ne)\s*$
 
 ```
 
@@ -85,12 +86,12 @@ of type [RegistryClassResolvingService](../nrich-registry-api/src/main/java/net/
 This module is meant to be used through REST API and as such exposes multiple endpoints. For a detailed description of each endpoint see `nrich-registry` [README.MD](../nrich-registry/README.md).
 Bellow is just a short overview of available endpoints (all methods use HTTP POST method):
 
-| request path                          | description                                                                                    |
-|---------------------------------------|------------------------------------------------------------------------------------------------|
-| `nrich/registry/configuration/fetch`  | Fetches configuration of all entities (used on client for generating dynamic forms and tables) |
-| `nrich/registry/data/list-bulk`       | Lists multiple registry entities                                                               |
-| `nrich/registry/data/list`            | List a single registry entity (also supports searching if query parameter is specified)        |
-| `nrich/registry/data/create`          | Creates registry entity                                                                        |
-| `nrich/registry/data/update`          | Update registry entity                                                                         |
-| `nrich/registry/data/delete`          | Deletes registry entity                                                                        |
-| `nrich/registry/history`              | List all the revisions of the entity (available only if envers is on classpath)                |
+| request path                         | description                                                                                    |
+|--------------------------------------|------------------------------------------------------------------------------------------------|
+| `nrich/registry/configuration/fetch` | Fetches configuration of all entities (used on client for generating dynamic forms and tables) |
+| `nrich/registry/data/list-bulk`      | Lists multiple registry entities                                                               |
+| `nrich/registry/data/list`           | List a single registry entity (also supports searching if query parameter is specified)        |
+| `nrich/registry/data/create`         | Creates registry entity                                                                        |
+| `nrich/registry/data/update`         | Update registry entity                                                                         |
+| `nrich/registry/data/delete`         | Deletes registry entity                                                                        |
+| `nrich/registry/history`             | List all the revisions of the entity (available only if envers is on classpath)                |

--- a/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/properties/NrichRegistryProperties.java
+++ b/nrich-registry-spring-boot-starter/src/main/java/net/croz/nrich/registry/starter/properties/NrichRegistryProperties.java
@@ -29,12 +29,14 @@ import java.util.List;
  * @param registrySearch                          Registry search configuration used by {@link net.croz.nrich.search.converter.DefaultStringToTypeConverter}.
  * @param defaultConverterEnabled                 Whether default string to type converter ({@link net.croz.nrich.search.converter.DefaultStringToTypeConverter}) used for converting strings to property values when searching registry is enabled.
  * @param defaultJavaToJavascriptConverterEnabled Whether default Java to Javascript type converter ({@link net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter}) used for converting Java to Javascript types is enabled.
+ * @param registryModelMapperCustomizerEnabled    Whether default ModelMapper customizer  ({@link net.croz.nrich.registry.data.customizer.RegistryDataModelMapperCustomizer}) used for skipping ignored properties when updating registry entities is enabled.
  * @param registryConfiguration                   Registry configuration used for defining entities and groups which will be managed.
  */
 @ConfigurationProperties("nrich.registry")
 public record NrichRegistryProperties(List<String> defaultReadOnlyPropertyList, @DefaultValue @NestedConfigurationProperty RegistrySearchProperties registrySearch,
                                       @DefaultValue("true") boolean defaultConverterEnabled,
                                       @DefaultValue("true") boolean defaultJavaToJavascriptConverterEnabled,
+                                      @DefaultValue("true") boolean registryModelMapperCustomizerEnabled,
                                       RegistryConfiguration registryConfiguration) {
 
     /**

--- a/nrich-registry-spring-boot-starter/src/test/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfigurationTest.java
+++ b/nrich-registry-spring-boot-starter/src/test/java/net/croz/nrich/registry/starter/configuration/NrichRegistryAutoConfigurationTest.java
@@ -22,6 +22,7 @@ import net.croz.nrich.formconfiguration.api.customizer.FormConfigurationMappingC
 import net.croz.nrich.javascript.api.converter.JavaToJavascriptTypeConverter;
 import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionService;
 import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
+import net.croz.nrich.registry.api.core.customizer.ModelMapperCustomizer;
 import net.croz.nrich.registry.api.core.model.RegistryConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryGroupDefinitionConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryOverrideConfigurationHolder;
@@ -79,6 +80,7 @@ class NrichRegistryAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(RegistryHistoryService.class);
             assertThat(context).doesNotHaveBean(RegistryEnumService.class);
             assertThat(context).doesNotHaveBean(FormConfigurationMappingCustomizer.class);
+            assertThat(context).doesNotHaveBean(ModelMapperCustomizer.class);
         });
     }
 
@@ -154,6 +156,7 @@ class NrichRegistryAutoConfigurationTest {
             assertThat(context).hasSingleBean(JavaToJavascriptTypeConversionService.class);
             assertThat(context).hasSingleBean(RegistryEnumService.class);
             assertThat(context).hasSingleBean(NrichRegistryProperties.class);
+            assertThat(context).hasSingleBean(ModelMapperCustomizer.class);
             assertThat(context.getBean(NrichRegistryProperties.class).registrySearch()).isNotNull();
 
             assertThat(context).doesNotHaveBean(RegistryConfigurationController.class);
@@ -201,5 +204,14 @@ class NrichRegistryAutoConfigurationTest {
             // then
             assertThat(registryProperties.registryConfiguration().getOverrideConfigurationHolderList()).containsExactly(holder);
         });
+    }
+
+    @Test
+    void shouldNotCreateRegistryModelMapperCustomizerWhenCreationIsDisabled() {
+        // expect
+        contextRunner.withPropertyValues(REGISTRY_CONFIGURATION).withBean(LocalValidatorFactoryBean.class)
+            .withPropertyValues("nrich.registry.registry-model-mapper-customizer-enabled=false").run(context ->
+                assertThat(context).doesNotHaveBean(ModelMapperCustomizer.class)
+            );
     }
 }

--- a/nrich-registry/src/main/java/net/croz/nrich/registry/data/customizer/RegistryDataModelMapperCustomizer.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/data/customizer/RegistryDataModelMapperCustomizer.java
@@ -1,0 +1,44 @@
+package net.croz.nrich.registry.data.customizer;
+
+import lombok.RequiredArgsConstructor;
+import net.croz.nrich.registry.api.core.customizer.ModelMapperCustomizer;
+import net.croz.nrich.registry.api.core.customizer.ModelMapperType;
+import net.croz.nrich.registry.api.core.model.RegistryOverrideConfiguration;
+import net.croz.nrich.registry.api.core.model.RegistryOverrideConfigurationHolder;
+import org.modelmapper.ModelMapper;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class RegistryDataModelMapperCustomizer implements ModelMapperCustomizer {
+
+    private final List<RegistryOverrideConfigurationHolder> registryOverrideConfigurationHolderList;
+
+    @Override
+    public void customize(ModelMapperType type, ModelMapper modelMapper) {
+        if (type != ModelMapperType.DATA || CollectionUtils.isEmpty(registryOverrideConfigurationHolderList)) {
+            return;
+        }
+
+        registryOverrideConfigurationHolderList.forEach(registryOverrideConfigurationHolder -> {
+            List<String> ignoredPropertyList = Optional.ofNullable(registryOverrideConfigurationHolder.getOverrideConfiguration())
+                .map(RegistryOverrideConfiguration::getIgnoredPropertyList)
+                .orElse(Collections.emptyList());
+
+            if (ignoredPropertyList.isEmpty()) {
+                return;
+            }
+
+            modelMapper.getConfiguration().setPropertyCondition(context -> {
+                if (context.getParent() != null && registryOverrideConfigurationHolder.getType().equals(context.getParent().getDestinationType())) {
+                    return context.getMapping().getDestinationProperties().stream().noneMatch(property -> ignoredPropertyList.contains(property.getName()));
+                }
+
+                return true;
+            });
+        });
+    }
+}

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/RegistryTestConfiguration.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/RegistryTestConfiguration.java
@@ -26,6 +26,8 @@ import net.croz.nrich.javascript.api.service.JavaToJavascriptTypeConversionServi
 import net.croz.nrich.javascript.converter.DefaultJavaToJavascriptTypeConverter;
 import net.croz.nrich.javascript.service.DefaultJavaToJavascriptTypeConversionService;
 import net.croz.nrich.registry.api.configuration.service.RegistryConfigurationService;
+import net.croz.nrich.registry.api.core.customizer.ModelMapperCustomizer;
+import net.croz.nrich.registry.api.core.customizer.ModelMapperType;
 import net.croz.nrich.registry.api.core.model.RegistryConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryGroupDefinitionConfiguration;
 import net.croz.nrich.registry.api.core.model.RegistryOverrideConfiguration;
@@ -49,6 +51,7 @@ import net.croz.nrich.registry.core.service.EntityManagerRegistryEntityFinderSer
 import net.croz.nrich.registry.core.service.RegistryConfigurationResolverService;
 import net.croz.nrich.registry.core.support.ManagedTypeWrapper;
 import net.croz.nrich.registry.data.controller.RegistryDataController;
+import net.croz.nrich.registry.data.customizer.RegistryDataModelMapperCustomizer;
 import net.croz.nrich.registry.data.service.DefaultRegistryDataRequestConversionService;
 import net.croz.nrich.registry.data.service.DefaultRegistryDataService;
 import net.croz.nrich.registry.data.service.RegistryDataRequestConversionService;
@@ -130,8 +133,17 @@ public class RegistryTestConfiguration {
     }
 
     @Bean
-    public ModelMapper registryDataModelMapper() {
-        return strictModelMapper();
+    ModelMapperCustomizer registryDataModelMapperCustomizer(RegistryConfiguration registryConfiguration) {
+        return new RegistryDataModelMapperCustomizer(registryConfiguration.getOverrideConfigurationHolderList());
+    }
+
+    @Bean
+    public ModelMapper registryDataModelMapper(@Autowired(required = false) List<ModelMapperCustomizer> modelMapperCustomizerList) {
+        ModelMapper modelMapper = strictModelMapper();
+
+        modelMapperCustomizerList.forEach(modelMapperCustomizer -> modelMapperCustomizer.customize(ModelMapperType.DATA, modelMapper));
+
+        return modelMapper;
     }
 
     @Bean

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/customizer/RegistryDataModelMapperCustomizerTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/customizer/RegistryDataModelMapperCustomizerTest.java
@@ -1,0 +1,64 @@
+package net.croz.nrich.registry.data.customizer;
+
+import net.croz.nrich.registry.api.core.customizer.ModelMapperType;
+import net.croz.nrich.registry.data.stub.RegistryTestEntity;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+
+import static net.croz.nrich.registry.data.testutil.RegistryDataModelMapperCustomizerGeneratingUtil.createRegistryOverrideConfigurationHolderList;
+import static net.croz.nrich.registry.data.testutil.RegistryDataModelMapperCustomizerGeneratingUtil.createRegistryTestEntity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class RegistryDataModelMapperCustomizerTest {
+
+    private final RegistryDataModelMapperCustomizer customizer = new RegistryDataModelMapperCustomizer(createRegistryOverrideConfigurationHolderList());
+
+    private final ModelMapper modelMapper = new ModelMapper();
+
+    @Test
+    void shouldNotFailForNullConfigurationHolderList() {
+        // given
+        RegistryDataModelMapperCustomizer customizerWithNullList = new RegistryDataModelMapperCustomizer(null);
+
+        // when
+        Exception thrown = catchException(() -> customizerWithNullList.customize(ModelMapperType.DATA, modelMapper));
+
+        // then
+        assertThat(thrown).isNull();
+    }
+
+    @Test
+    void shouldNotCustomizeForNonRegistryModelMapperType() {
+        // given
+        ModelMapper modelMapperMock = mock(ModelMapper.class);
+
+        // when
+        customizer.customize(ModelMapperType.BASE, modelMapperMock);
+
+        // then
+        verifyNoInteractions(modelMapperMock);
+    }
+
+    @Test
+    void shouldSkipMappingIgnoredPropertyList() {
+        // given
+        Integer age = 1111;
+        RegistryTestEntity source = createRegistryTestEntity();
+        RegistryTestEntity destination = new RegistryTestEntity();
+        destination.setAge(age);
+
+        // when
+        customizer.customize(ModelMapperType.DATA, modelMapper);
+
+        // and when
+        modelMapper.map(source, destination);
+
+        // then
+        assertThat(destination.getAge()).isEqualTo(age);
+        assertThat(destination.getName()).isEqualTo(source.getName());
+        assertThat(destination.getId()).isEqualTo(source.getId());
+    }
+}

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataModelMapperCustomizerGeneratingUtil.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/data/testutil/RegistryDataModelMapperCustomizerGeneratingUtil.java
@@ -1,0 +1,45 @@
+package net.croz.nrich.registry.data.testutil;
+
+import net.croz.nrich.registry.api.core.model.RegistryOverrideConfiguration;
+import net.croz.nrich.registry.api.core.model.RegistryOverrideConfigurationHolder;
+import net.croz.nrich.registry.data.stub.RegistryTestEntity;
+import net.croz.nrich.registry.data.stub.RegistryTestEntityWithoutAssociation;
+import net.croz.nrich.registry.data.stub.RegistryTestGroupType;
+
+import java.util.List;
+
+public final class RegistryDataModelMapperCustomizerGeneratingUtil {
+
+    private RegistryDataModelMapperCustomizerGeneratingUtil() {
+    }
+
+    public static List<RegistryOverrideConfigurationHolder> createRegistryOverrideConfigurationHolderList() {
+        RegistryOverrideConfiguration overrideConfiguration = new RegistryOverrideConfiguration();
+
+        overrideConfiguration.setIgnoredPropertyList(List.of("age"));
+
+        return List.of(
+            RegistryOverrideConfigurationHolder.builder()
+                .type(RegistryTestGroupType.class)
+                .build(),
+            RegistryOverrideConfigurationHolder.builder()
+                .type(RegistryTestEntityWithoutAssociation.class)
+                .overrideConfiguration(null)
+                .build(),
+            RegistryOverrideConfigurationHolder.builder()
+                .type(RegistryTestEntity.class)
+                .overrideConfiguration(overrideConfiguration)
+                .build()
+        );
+    }
+
+    public static RegistryTestEntity createRegistryTestEntity() {
+        RegistryTestEntity entity = new RegistryTestEntity();
+
+        entity.setName("name");
+        entity.setAge(10);
+        entity.setId(1L);
+
+        return entity;
+    }
+}


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.8.0
* Module:
nrich-registry-api, nrich-registry, nrich-registry-spring-boot-starter

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add support for ignoring properties when updating registry entities

### Details

Add support for ignoring properties when updating registry entities. Registry configuration provided in ignoredPropertyList is now used to exclude those properties from being updated when updating registry entity.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
