### PR TITLE
Added NrichValidationProperties to enable generating of spring-configuration-metadata.json

### DIFF
--- a/nrich-validation-spring-boot-starter/README.md
+++ b/nrich-validation-spring-boot-starter/README.md
@@ -4,10 +4,13 @@
 
 ## Overview
 
-Spring Boot starter for `nrich-validation` module. The purpose of `nrich-validation` module is converting constraints defined on the server side in a form that can be used on the client side thus
+Spring Boot starter for [`nrich-validation`][nrich-validation-url] module. The purpose of `nrich-validation` module is converting constraints defined on the server side in a form that can be used on
+the client side thus
 avoiding repeating constraints on both server and client side.
-Starter module provides a `@Configuration` class (`NrichValidationAutoConfiguration`) with default configuration of `nrich-validation` module (while allowing for overriding with conditional
-annotations) and does automatic registration through `spring.factories`.
+
+Starter module provides a `@Configuration` class [`NrichValidationAutoConfiguration`][nrich-validation-auto-configuration-url]) with default configuration of
+[`nrich-validation`][nrich-validation-url] module, a `@ConfigurationProperties` class ([`NrichValidationProperties`][nrich-validation-properties-url]) with default
+configuration values and does automatic bean registration with `spring.factories`. The configuration class permits overriding with the help of conditional annotations.
 
 ## Usage
 
@@ -52,9 +55,9 @@ The default configuration values in yaml format for easier modification are give
 ```yaml
 
 nrich.validation:
-  register-messages: true
-  register-constraint-validators: true
-  validator-package-list: net.croz.nrich.validation.constraint.validator
+    register-messages: true
+    register-constraint-validators: true
+    validator-package-list: net.croz.nrich.validation.constraint.validator
 
 ```
 
@@ -106,3 +109,11 @@ Difference between `@ValidFile` and `@ValidFileResolvable` is that the former re
 | allowed-content-type-list | Property name from which allowed content type list is resolved (empty value allows all content types)                |
 | allowed-extension-list    | Property name from which allowed extension list is resolved (case-insensitive, empty value allows all content types) |
 | allowed-file-name-regex   | Property name from which allowed file name regex is resolved (empty value allows all file names)                     |
+
+[//]: # (Reference links for readability)
+
+[nrich-validation-url]: ../nrich-validation/README.md
+
+[nrich-validation-auto-configuration-url]: ../nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfiguration.java
+
+[nrich-validation-properties-url]: ../nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/properties/NrichValidationProperties.java

--- a/nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfiguration.java
+++ b/nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfiguration.java
@@ -20,20 +20,21 @@ package net.croz.nrich.validation.starter.configuration;
 import lombok.RequiredArgsConstructor;
 import net.croz.nrich.validation.api.mapping.ConstraintValidatorRegistrar;
 import net.croz.nrich.validation.constraint.mapping.DefaultConstraintValidatorRegistrar;
+import net.croz.nrich.validation.starter.properties.NrichValidationProperties;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.boot.autoconfigure.validation.ValidationConfigurationCustomizer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.AbstractResourceBasedMessageSource;
 
 import jakarta.validation.Validator;
-import java.util.List;
 
+@EnableConfigurationProperties(NrichValidationProperties.class)
 @Configuration(proxyBeanMethods = false)
 public class NrichValidationAutoConfiguration {
 
@@ -60,8 +61,8 @@ public class NrichValidationAutoConfiguration {
 
     @ConditionalOnProperty(name = "nrich.validation.register-constraint-validators", havingValue = "true", matchIfMissing = true)
     @Bean
-    ConstraintValidatorRegistrar constraintMappingRegistrar(@Value("${nrich.validation.validator-package-list:net.croz.nrich.validation.constraint.validator}") List<String> validatorPackageList) {
-        return new DefaultConstraintValidatorRegistrar(validatorPackageList);
+    ConstraintValidatorRegistrar constraintMappingRegistrar(NrichValidationProperties validationProperties) {
+        return new DefaultConstraintValidatorRegistrar(validationProperties.validatorPackageList());
     }
 
     @ConditionalOnProperty(name = "nrich.validation.register-constraint-validators", havingValue = "true", matchIfMissing = true)

--- a/nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/properties/NrichValidationProperties.java
+++ b/nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/properties/NrichValidationProperties.java
@@ -1,0 +1,19 @@
+package net.croz.nrich.validation.starter.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import java.util.List;
+
+/**
+ * @param registerMessages             Whether default constraint messages should be registered
+ * @param registerConstraintValidators Whether default validators should be registered
+ * @param validatorPackageList         A list containing all the validator packages that will be registered automatically
+ */
+@EnableConfigurationProperties(NrichValidationProperties.class)
+@ConfigurationProperties("nrich.validation")
+public record NrichValidationProperties(@DefaultValue("true") boolean registerMessages, @DefaultValue("true") boolean registerConstraintValidators,
+                                        @DefaultValue("net.croz.nrich.validation.constraint.validator") List<String> validatorPackageList) {
+
+}

--- a/nrich-validation-spring-boot-starter/src/test/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfigurationTest.java
+++ b/nrich-validation-spring-boot-starter/src/test/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfigurationTest.java
@@ -18,6 +18,7 @@
 package net.croz.nrich.validation.starter.configuration;
 
 import net.croz.nrich.validation.api.mapping.ConstraintValidatorRegistrar;
+import net.croz.nrich.validation.starter.properties.NrichValidationProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
@@ -42,6 +43,7 @@ class NrichValidationAutoConfigurationTest {
             assertThat(context).hasSingleBean(NrichValidationAutoConfiguration.ValidationMessageSourceRegistrar.class);
             assertThat(context).hasSingleBean(ConstraintValidatorRegistrar.class);
             assertThat(context).hasSingleBean(ValidationConfigurationCustomizer.class);
+            assertThat(context).hasSingleBean(NrichValidationProperties.class);
         });
     }
 


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.11.0
* Module:
nrich-validation-autoconfiguration

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Added NrichValidationProperties to enable generating of spring-configuration-metadata.json

### Details

Added NrichValidationProperties to enable generating of spring-configuration-metadata.json

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
