### PR TITLE
Fix deeply nested paths in form configuration

### DIFF
--- a/nrich-form-configuration/src/main/java/net/croz/nrich/formconfiguration/service/DefaultFormConfigurationService.java
+++ b/nrich-form-configuration/src/main/java/net/croz/nrich/formconfiguration/service/DefaultFormConfigurationService.java
@@ -94,7 +94,7 @@ public class DefaultFormConfigurationService implements FormConfigurationService
             }
 
             if (shouldResolveConstraintListForType(propertyDescriptor)) {
-                recursiveResolveFieldConfiguration(propertyDescriptor.getElementClass(), constrainedPropertyConfigurationList, propertyName);
+                recursiveResolveFieldConfiguration(propertyDescriptor.getElementClass(), constrainedPropertyConfigurationList, propertyPath);
             }
         });
 

--- a/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/FormConfigurationTestConfiguration.java
+++ b/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/FormConfigurationTestConfiguration.java
@@ -25,6 +25,7 @@ import net.croz.nrich.formconfiguration.service.DefaultConstrainedPropertyValida
 import net.croz.nrich.formconfiguration.service.DefaultFormConfigurationAnnotationResolvingService;
 import net.croz.nrich.formconfiguration.service.DefaultFormConfigurationService;
 import net.croz.nrich.formconfiguration.service.MessageSourceFieldErrorMessageResolverService;
+import net.croz.nrich.formconfiguration.stub.FormConfigurationServiceDeeplyNestedTestRequest;
 import net.croz.nrich.formconfiguration.stub.FormConfigurationServiceNestedIgnoredTestRequest;
 import net.croz.nrich.formconfiguration.stub.FormConfigurationServiceNestedTestRequest;
 import net.croz.nrich.formconfiguration.stub.FormConfigurationServiceTestRequest;
@@ -47,6 +48,8 @@ public class FormConfigurationTestConfiguration {
     public static final String SIMPLE_FORM_CONFIGURATION_FORM_ID = "simpleForm.formId";
 
     public static final String NESTED_FORM_CONFIGURATION_FORM_ID = "nestedForm.formId";
+
+    public static final String DEEPLY_NESTED_FORM_CONFIGURATION_FORM_ID = "deeplyNestedForm.formId";
 
     public static final String NESTED_FORM_NOT_VALIDATED_CONFIGURATION_FORM_ID = "nestedFormNotValidated.formId";
 
@@ -87,6 +90,7 @@ public class FormConfigurationTestConfiguration {
 
         formIdConstraintHolderMap.put(SIMPLE_FORM_CONFIGURATION_FORM_ID, FormConfigurationServiceTestRequest.class);
         formIdConstraintHolderMap.put(NESTED_FORM_CONFIGURATION_FORM_ID, FormConfigurationServiceNestedTestRequest.class);
+        formIdConstraintHolderMap.put(DEEPLY_NESTED_FORM_CONFIGURATION_FORM_ID, FormConfigurationServiceDeeplyNestedTestRequest.class);
         formIdConstraintHolderMap.put(NESTED_FORM_NOT_VALIDATED_CONFIGURATION_FORM_ID, FormConfigurationServiceNestedIgnoredTestRequest.class);
 
         return new DefaultFormConfigurationService(validator.getValidator(), formIdConstraintHolderMap, constrainedPropertyValidatorConverterServiceList, javaToJavascriptTypeConversionService);

--- a/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/service/DefaultFormConfigurationServiceTest.java
+++ b/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/service/DefaultFormConfigurationServiceTest.java
@@ -43,9 +43,11 @@ class DefaultFormConfigurationServiceTest {
         List<FormConfiguration> resultList = formConfigurationService.fetchFormConfigurationList();
 
         // then
-        assertThat(resultList).hasSize(4);
+        assertThat(resultList).hasSize(5);
         assertThat(resultList).extracting("formId").containsExactlyInAnyOrder(
-            FormConfigurationTestConfiguration.SIMPLE_FORM_CONFIGURATION_FORM_ID, FormConfigurationTestConfiguration.NESTED_FORM_CONFIGURATION_FORM_ID,
+            FormConfigurationTestConfiguration.SIMPLE_FORM_CONFIGURATION_FORM_ID,
+            FormConfigurationTestConfiguration.NESTED_FORM_CONFIGURATION_FORM_ID,
+            FormConfigurationTestConfiguration.DEEPLY_NESTED_FORM_CONFIGURATION_FORM_ID,
             FormConfigurationTestConfiguration.NESTED_FORM_NOT_VALIDATED_CONFIGURATION_FORM_ID,
             "annotatedForm.formId"
         );
@@ -143,6 +145,32 @@ class DefaultFormConfigurationServiceTest {
         assertThat(valueValidatorConfiguration.name()).isEqualTo("Min");
         assertThat(valueValidatorConfiguration.argumentMap().values()).containsExactly(10L);
         assertThat(valueValidatorConfiguration.errorMessage()).isEqualTo("Minimum value is: 10");
+    }
+
+    @Test
+    void shouldFetchDeeplyNestedFormConfigurationWithFullPaths() {
+        // given
+        List<String> formIdList = List.of(FormConfigurationTestConfiguration.DEEPLY_NESTED_FORM_CONFIGURATION_FORM_ID);
+
+        // when
+        List<FormConfiguration> resultList = formConfigurationService.fetchFormConfigurationList(formIdList);
+
+        // then
+        assertThat(resultList).hasSize(1);
+
+        // and when
+        FormConfiguration formConfiguration = resultList.get(0);
+
+        // then
+        assertThat(formConfiguration.constrainedPropertyConfigurationList()).extracting(ConstrainedPropertyConfiguration::path).containsExactlyInAnyOrder(
+            "rootName",
+            "nested.topLevelName",
+            "nested.doubleNested.name",
+            "nested.doubleNested.request.name",
+            "nested.doubleNested.request.lastName",
+            "nested.doubleNested.request.timestamp",
+            "nested.doubleNested.request.value"
+        );
     }
 
     @Test

--- a/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/stub/FormConfigurationServiceDeepNestedTestRequest.java
+++ b/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/stub/FormConfigurationServiceDeepNestedTestRequest.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.formconfiguration.stub;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+@Setter
+@Getter
+public class FormConfigurationServiceDeepNestedTestRequest {
+
+    @NotNull
+    private String topLevelName;
+
+    @Valid
+    private FormConfigurationServiceNestedTestRequest doubleNested;
+
+}

--- a/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/stub/FormConfigurationServiceDeeplyNestedTestRequest.java
+++ b/nrich-form-configuration/src/test/java/net/croz/nrich/formconfiguration/stub/FormConfigurationServiceDeeplyNestedTestRequest.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.formconfiguration.stub;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+@Setter
+@Getter
+public class FormConfigurationServiceDeeplyNestedTestRequest {
+
+    @NotNull
+    private String rootName;
+
+    @Valid
+    private FormConfigurationServiceDeepNestedTestRequest nested;
+
+}


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.12
* Module:
nrich-form-configuration
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Fix deeply nested paths in form configuration

### Details

Fix deeply nested paths in form configuration. Now form configuration will have full path to the property instead of only single level nesting.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
