### PR TITLE
Add Slice support to nrich-search

### DIFF
--- a/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/repository/SearchExecutor.java
+++ b/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/repository/SearchExecutor.java
@@ -20,6 +20,7 @@ package net.croz.nrich.search.api.repository;
 import net.croz.nrich.search.api.model.SearchConfiguration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -78,6 +79,19 @@ public interface SearchExecutor<T> {
      * @return a {@link Page} of entities matching the given conditions applied from search request
      */
     <R, P> Page<P> findAll(R request, SearchConfiguration<T, P, R> searchConfiguration, Pageable pageable);
+
+    /**
+     * Returns a {@link Slice} of entities matching conditions applied from search request. In case no match could be found, an empty {@link Slice} is returned.
+     * Unlike {@link #findAll(Object, SearchConfiguration, Pageable)}, no count query is executed; the returned {@link Slice} only knows whether a next slice exists.
+     *
+     * @param request             search request that contains query values
+     * @param searchConfiguration configuration that decides how query should be built
+     * @param pageable            can be {@literal null}.
+     * @param <R>                 type of request
+     * @param <P>                 projection class
+     * @return a {@link Slice} of entities matching the given conditions applied from search request
+     */
+    <R, P> Slice<P> findAllSliced(R request, SearchConfiguration<T, P, R> searchConfiguration, Pageable pageable);
 
     /**
      * Returns the number of instances matching conditions applied from search request.

--- a/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/repository/StringSearchExecutor.java
+++ b/nrich-search-repository-api/src/main/java/net/croz/nrich/search/api/repository/StringSearchExecutor.java
@@ -20,6 +20,7 @@ package net.croz.nrich.search.api.repository;
 import net.croz.nrich.search.api.model.SearchConfiguration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -74,6 +75,19 @@ public interface StringSearchExecutor<T> {
      * @return a {@link Page} of entities matching the given conditions applied from search term and property to search list
      */
     <P> Page<P> findAll(String searchTerm, List<String> propertyToSearchList, SearchConfiguration<T, P, Map<String, Object>> searchConfiguration, Pageable pageable);
+
+    /**
+     * Returns a {@link Slice} of entities matching conditions applied from search term and property to search list. In case no match could be found, an empty {@link Slice} is returned.
+     * Unlike {@link #findAll(String, List, SearchConfiguration, Pageable)}, no count query is executed; the returned {@link Slice} only knows whether a next slice exists.
+     *
+     * @param searchTerm           search term to search
+     * @param propertyToSearchList properties to search
+     * @param searchConfiguration  configuration that decides how query should be built
+     * @param pageable             can be {@literal null}.
+     * @param <P>                  projection class
+     * @return a {@link Slice} of entities matching the given conditions applied from search term and property to search list
+     */
+    <P> Slice<P> findAllSliced(String searchTerm, List<String> propertyToSearchList, SearchConfiguration<T, P, Map<String, Object>> searchConfiguration, Pageable pageable);
 
     /**
      * Returns the number of instances matching conditions applied from search term and property to search list.

--- a/nrich-search/README.md
+++ b/nrich-search/README.md
@@ -202,6 +202,12 @@ public class CarSearchService {
 }
 ```
 
+If the total result count is not needed (e.g. an infinite-scroll or "load more" UI), `findAllSliced` returns a [`Slice<CarSearchResult>`][slice-url] instead of `Page` and skips the COUNT(*) query:
+
+```java
+return carRepository.findAllSliced(request, searchConfiguration, PageableUtil.convertToPageable(request));
+```
+
 In this service we have defined that the query will be executed on the entity `Car` based on the `CarSearchRequest` class and that results of the search will be of type `CarSearchResult`.
 This was defined using [`SearchConfiguration`][search-configuration-url] class and its method `.resultClass(CarSearchResult.class)`.
 [`SearchConfiguration`][search-configuration-url] class dictates how the query should be formed by performing mappings of properties from defined query class to the properties in the target entity.
@@ -326,6 +332,12 @@ public class CarSearchService {
 }
 ```
 
+As with `SearchExecutor`, `findAllSliced` returns a [`Slice<CarSearchResult>`][slice-url] and avoids the COUNT(*) query:
+
+```java
+return carRepository.findAllSliced(request.getSearchTerm(), request.getPropertyToSearchList(), searchConfiguration, Pageable.unpaged());
+```
+
 When using `simpleSearch` method we are searching the `Car` entity by properties supplied in `propertyToSearchList`.
 When property is not a String type conversion is attempted using [`StringToTypeConverter`][string-to-type-converter-url] and if it succeeds then property is searched otherwise it is ignored.
 
@@ -430,3 +442,5 @@ This can be also customized for individual associations by specifying a `SearchJ
 [base-sortable-pageable-request-url]: ../nrich-search-api/src/main/java/net/croz/nrich/search/api/request/BaseSortablePageableRequest.java
 
 [default-search-operator-url]: ../nrich-search-api/src/main/java/net/croz/nrich/search/api/model/operator/DefaultSearchOperator.java
+
+[slice-url]: https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/Slice.html

--- a/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaSearchExecutor.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaSearchExecutor.java
@@ -24,6 +24,8 @@ import net.croz.nrich.search.util.QueryUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -93,13 +95,31 @@ public class JpaSearchExecutor<T> implements SearchExecutor<T> {
     }
 
     @Override
+    public <R, P> Slice<P> findAllSliced(R request, SearchConfiguration<T, P, R> searchConfiguration, Pageable pageable) {
+        CriteriaQuery<P> query = queryBuilder.buildQuery(request, searchConfiguration, pageable.getSort());
+        TypedQuery<P> typedQuery = entityManager.createQuery(query);
+
+        int pageSize = 0;
+        if (pageable.isPaged()) {
+            pageSize = pageable.getPageSize();
+            typedQuery.setFirstResult((int) pageable.getOffset()).setMaxResults(pageSize + 1);
+        }
+
+        List<P> resultList = typedQuery.getResultList();
+        boolean hasNext = pageable.isPaged() && resultList.size() > pageSize;
+        List<P> content = hasNext ? resultList.subList(0, pageSize) : resultList;
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    @Override
     public <R, P> long count(R request, SearchConfiguration<T, P, R> searchConfiguration) {
         return executeCountQuery(request, searchConfiguration);
     }
 
     @Override
     public <R, P> boolean exists(R request, SearchConfiguration<T, P, R> searchConfiguration) {
-        CriteriaQuery<Integer>  query = queryBuilder.buildExistsQuery(request, searchConfiguration);
+        CriteriaQuery<Integer> query = queryBuilder.buildExistsQuery(request, searchConfiguration);
 
         return entityManager.createQuery(query).setMaxResults(1).getResultList().size() == 1;
     }

--- a/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaStringSearchExecutor.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaStringSearchExecutor.java
@@ -25,6 +25,8 @@ import net.croz.nrich.search.util.QueryUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -106,6 +108,26 @@ public class JpaStringSearchExecutor<T> implements StringSearchExecutor<T> {
         }
 
         return new PageImpl<>(typedQuery.getResultList());
+    }
+
+    @Override
+    public <P> Slice<P> findAllSliced(String searchTerm, List<String> propertyToSearchList, SearchConfiguration<T, P, Map<String, Object>> searchConfiguration, Pageable pageable) {
+        Map<String, Object> searchMap = convertToMap(searchTerm, propertyToSearchList, searchConfiguration);
+
+        CriteriaQuery<P> query = queryBuilder.buildQuery(searchMap, searchConfiguration, pageable.getSort());
+        TypedQuery<P> typedQuery = entityManager.createQuery(query);
+
+        int pageSize = 0;
+        if (pageable.isPaged()) {
+            pageSize = pageable.getPageSize();
+            typedQuery.setFirstResult((int) pageable.getOffset()).setMaxResults(pageSize + 1);
+        }
+
+        List<P> resultList = typedQuery.getResultList();
+        boolean hasNext = pageable.isPaged() && resultList.size() > pageSize;
+        List<P> content = hasNext ? resultList.subList(0, pageSize) : resultList;
+
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 
     @Override

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaSearchExecutorTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaSearchExecutorTest.java
@@ -29,10 +29,14 @@ import net.croz.nrich.search.repository.stub.TestEntitySearchRepository;
 import net.croz.nrich.search.repository.stub.TestEntitySearchRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +45,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static net.croz.nrich.search.repository.testutil.JpaSearchRepositoryExecutorGeneratingUtil.generateListForSearch;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -140,6 +145,26 @@ class JpaSearchExecutorTest {
         assertThat(result).isNotEmpty();
         assertThat(result.getTotalPages()).isEqualTo(1);
         assertThat(result.getContent()).hasSize(5);
+    }
+
+    @MethodSource("shouldFindAllSlicedMethodSource")
+    @ParameterizedTest
+    void shouldFindAllSliced(TestEntitySearchRequest request, Pageable pageable, int expectedContentSize, boolean expectedHasNext) {
+        // when
+        Slice<TestEntity> result = testEntitySearchRepository.findAllSliced(request, SearchConfiguration.emptyConfiguration(), pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(expectedContentSize);
+        assertThat(result.hasNext()).isEqualTo(expectedHasNext);
+    }
+
+    private static Stream<Arguments> shouldFindAllSlicedMethodSource() {
+        return Stream.of(
+            Arguments.of(new TestEntitySearchRequest(null), PageRequest.of(0, 2), 2, true),
+            Arguments.of(new TestEntitySearchRequest(null), PageRequest.of(2, 2), 1, false),
+            Arguments.of(new TestEntitySearchRequest(null), Pageable.unpaged(), 5, false),
+            Arguments.of(new TestEntitySearchRequest("non existing name"), PageRequest.of(0, 1), 0, false)
+        );
     }
 
     @Test

--- a/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaStringSearchExecutorTest.java
+++ b/nrich-search/src/test/java/net/croz/nrich/search/repository/JpaStringSearchExecutorTest.java
@@ -23,10 +23,14 @@ import net.croz.nrich.search.repository.stub.TestEntityStringSearchRepository;
 import net.croz.nrich.search.repository.stub.TestStringSearchEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +40,7 @@ import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static net.croz.nrich.search.repository.testutil.JpaSearchRepositoryExecutorGeneratingUtil.generateListForStringSearch;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -124,6 +129,26 @@ class JpaStringSearchExecutorTest {
         assertThat(result).isNotEmpty();
         assertThat(result.getTotalPages()).isEqualTo(1);
         assertThat(result.getContent()).hasSize(5);
+    }
+
+    @MethodSource("shouldFindAllSlicedMethodSource")
+    @ParameterizedTest
+    void shouldFindAllSliced(String searchTerm, List<String> propertyToSearchList, Pageable pageable, int expectedContentSize, boolean expectedHasNext) {
+        // when
+        Slice<TestStringSearchEntity> result = testEntityStringSearchRepository.findAllSliced(searchTerm, propertyToSearchList, EMPTY_CONFIGURATION, pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(expectedContentSize);
+        assertThat(result.hasNext()).isEqualTo(expectedHasNext);
+    }
+
+    private static Stream<Arguments> shouldFindAllSlicedMethodSource() {
+        return Stream.of(
+            Arguments.of("10", List.of("ageFrom"), PageRequest.of(0, 2), 2, true),
+            Arguments.of("10", List.of("ageFrom"), PageRequest.of(2, 2), 1, false),
+            Arguments.of("10", List.of("ageFrom"), Pageable.unpaged(), 5, false),
+            Arguments.of("5555", List.of("age"), PageRequest.of(0, 1), 0, false)
+        );
     }
 
     @Test


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.13.0
* Module:
nrich-search, nrich-search-api

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add Slice support to nrich-search.

### Details

Add Slice support to nrich-search. Slice can now be used where instead of a Page when users are only interested if there are more results and don't need total count. This avoids additional count queries.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
