### PR TITLE
Fix registry history pagination

### DIFF
--- a/nrich-registry/src/main/java/net/croz/nrich/registry/history/service/DefaultRegistryHistoryService.java
+++ b/nrich-registry/src/main/java/net/croz/nrich/registry/history/service/DefaultRegistryHistoryService.java
@@ -83,17 +83,13 @@ public class DefaultRegistryHistoryService implements RegistryHistoryService {
     @Transactional(readOnly = true)
     public <T> Page<EntityWithRevision<T>> historyList(ListRegistryHistoryRequest request) {
         AuditQuery auditQuery = createAuditQuery(request);
+        Pageable pageable = PageableUtil.convertToPageable(request.pageNumber(), request.pageSize());
 
         addOrder(auditQuery, request.sortPropertyList());
 
-        List<?> resultList = auditQuery
-            .setFirstResult(request.pageNumber())
-            .setMaxResults(request.pageSize()).getResultList();
+        List<?> resultList = auditQuery.setFirstResult((int) pageable.getOffset()).setMaxResults(pageable.getPageSize()).getResultList();
 
         List<EntityWithRevision<T>> entityWithRevisionList = convertToEntityRevisionList(resultList);
-
-        Pageable pageable = PageableUtil.convertToPageable(request.pageNumber(), request.pageSize());
-
         return PageableExecutionUtils.getPage(entityWithRevisionList, pageable, () -> executeCountQuery(createAuditQuery(request)));
     }
 

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/history/service/DefaultRegistryHistoryServiceTest.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/history/service/DefaultRegistryHistoryServiceTest.java
@@ -118,7 +118,25 @@ class DefaultRegistryHistoryServiceTest {
 
         // then
         assertThat(resultList).isNotEmpty();
-        assertThat(resultList.getContent()).extracting("entity.name").containsExactlyInAnyOrder("first", "name 0", "name 1", "name 2", "name 3", "name 4", "name 5", "name 6", "related", "parent");
+        assertThat(resultList.getContent()).extracting("entity.name").containsExactlyInAnyOrder(
+            "first", "name 0", "name 1", "name 2", "name 3", "name 4", "name 5", "name 6", "related", "parent"
+        );
+    }
+
+    @Test
+    void shouldReturnSecondPageOfRevisionsWhenPageNumberIsOne() {
+        // given
+        RegistryHistoryTestEntity entity = creteRegistryHistoryTestEntityRevisionList(entityManager, platformTransactionManager);
+        ListRegistryHistoryRequest request = listRegistryHistoryRequestWithDefaultSort(RegistryHistoryTestEntity.class.getName(), entity.getId(), 1, 10);
+
+        // when
+        Page<EntityWithRevision<RegistryHistoryTestEntity>> resultList = registryHistoryService.historyList(request);
+
+        // then
+        assertThat(resultList.getTotalElements()).isEqualTo(21);
+        assertThat(resultList.getContent()).extracting("entity.name").containsExactlyInAnyOrder(
+            "name 9", "name 10", "name 11", "name 12", "name 13", "name 14", "name 15", "name 16", "name 17", "name 18"
+        );
     }
 
     @Test

--- a/nrich-registry/src/test/java/net/croz/nrich/registry/history/testutil/RegistryHistoryGeneratingUtil.java
+++ b/nrich-registry/src/test/java/net/croz/nrich/registry/history/testutil/RegistryHistoryGeneratingUtil.java
@@ -126,9 +126,13 @@ public final class RegistryHistoryGeneratingUtil {
     }
 
     public static ListRegistryHistoryRequest listRegistryHistoryRequestWithDefaultSort(String className, Object id) {
+        return listRegistryHistoryRequestWithDefaultSort(className, id, 0, 10);
+    }
+
+    public static ListRegistryHistoryRequest listRegistryHistoryRequestWithDefaultSort(String className, Object id, int pageNumber, int pageSize) {
         List<SortProperty> sortPropertyList = List.of(new SortProperty(RegistryEnversConstants.REVISION_NUMBER_PROPERTY_NAME, SortDirection.ASC));
 
-        return new ListRegistryHistoryRequest(className, 0, 10, id, sortPropertyList);
+        return new ListRegistryHistoryRequest(className, pageNumber, pageSize, id, sortPropertyList);
     }
 
     public static ListRegistryHistoryRequest listRegistryHistoryRequest(String className, Object id) {


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
4.13.1
* Module:
nrich-registry
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Fix registry history pagination

### Details

Fix registry history pagination, instead of offset page number was used.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
