### PR TITLE
Default to strict validation for ValidFile and ValidFileResolvable co…

### DIFF
--- a/nrich-validation-api/src/main/java/net/croz/nrich/validation/api/constraint/ValidFile.java
+++ b/nrich-validation-api/src/main/java/net/croz/nrich/validation/api/constraint/ValidFile.java
@@ -73,6 +73,23 @@ public @interface ValidFile {
     String allowedFileNameRegex() default "";
 
     /**
+     * Whether a {@code null} content type causes validation to fail when {@link #allowedContentTypeList()} is non-empty.
+     * Default {@code true} (strict). Set to {@code false} to allow uploads without a {@code Content-Type} header
+     * through the content-type gate.
+     *
+     * @return require content type
+     */
+    boolean requireContentType() default true;
+
+    /**
+     * Whether a filename without a recognizable extension causes validation to fail when {@link #allowedExtensionList()} is non-empty.
+     * Default {@code true} (strict). Set to {@code false} to allow extensionless filenames through the extension gate.
+     *
+     * @return require extension
+     */
+    boolean requireExtension() default true;
+
+    /**
      * Defines several {@link ValidFile} annotations on the same element.
      *
      * @see ValidFile

--- a/nrich-validation-api/src/main/java/net/croz/nrich/validation/api/constraint/ValidFileResolvable.java
+++ b/nrich-validation-api/src/main/java/net/croz/nrich/validation/api/constraint/ValidFileResolvable.java
@@ -73,6 +73,22 @@ public @interface ValidFileResolvable {
     String allowedFileNameRegexPropertyName() default "nrich.constraint.file.allowed-file-name-regex";
 
     /**
+     * Property name from which the require-content-type flag is resolved (default property value {@code true}).
+     * When {@code true}, a null content type causes validation to fail whenever the allowed content type list is non-empty.
+     *
+     * @return require content type property name
+     */
+    String requireContentTypePropertyName() default "nrich.constraint.file.require-content-type";
+
+    /**
+     * Property name from which the require-extension flag is resolved (default property value {@code true}).
+     * When {@code true}, a filename without a recognizable extension causes validation to fail whenever the allowed extension list is non-empty.
+     *
+     * @return require extension property name
+     */
+    String requireExtensionPropertyName() default "nrich.constraint.file.require-extension";
+
+    /**
      * Defines several {@link ValidFileResolvable} annotations on the same element.
      *
      * @see ValidFileResolvable

--- a/nrich-validation-spring-boot-starter/README.md
+++ b/nrich-validation-spring-boot-starter/README.md
@@ -104,11 +104,13 @@ A list of available constraints and descriptions is given bellow:
 Difference between `@ValidFile` and `@ValidFileResolvable` is that the former resolves allowed values from environment. Searched properties are given bellow but can be overridden on each constraint
 (all properties are prefixed with nrich.constraint.file which is omitted for readability):
 
-| property                  | description                                                                                                          |
-|---------------------------|----------------------------------------------------------------------------------------------------------------------|
-| allowed-content-type-list | Property name from which allowed content type list is resolved (empty value allows all content types)                |
-| allowed-extension-list    | Property name from which allowed extension list is resolved (case-insensitive, empty value allows all content types) |
-| allowed-file-name-regex   | Property name from which allowed file name regex is resolved (empty value allows all file names)                     |
+| property                  | description                                                                                                                      |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| allowed-content-type-list | Property name from which allowed content type list is resolved (empty value allows all content types)                            |
+| allowed-extension-list    | Property name from which allowed extension list is resolved (case-insensitive, empty value allows all content types)             |
+| allowed-file-name-regex   | Property name from which allowed file name regex is resolved (empty value allows all file names)                                 |
+| require-content-type      | When `true` (default), a null `Content-Type` fails the content-type gate when `allowed-content-type-list` is set                 |
+| require-extension         | When `true` (default), a filename without a recognizable extension fails the extension gate when `allowed-extension-list` is set |
 
 [//]: # (Reference links for readability)
 

--- a/nrich-validation/README.md
+++ b/nrich-validation/README.md
@@ -209,6 +209,27 @@ public class ExampleRequest {
 
 will validate that file has content type of `text/plain`, extension `txt` and matches regex: `(?U)[\\w-.]+`
 
+By default the validator is strict: a null `Content-Type` (e.g. an HTTP request omitting the header) fails the content-type gate when `allowedContentTypeList` is non-empty, and a filename without a recognizable extension fails the extension gate when `allowedExtensionList` is non-empty. Set `requireContentType = false` or `requireExtension = false` to relax either gate individually:
+
+```java
+
+@Setter
+@Getter
+public class ExampleRequest {
+
+    @ValidFile(
+        allowedContentTypeList = "text/plain",
+        allowedExtensionList = "txt",
+        requireContentType = false
+    )
+    private MultipartFile file;
+
+}
+
+```
+
+Content-type matching is case-insensitive (per RFC 6838), so `IMAGE/PNG` and `image/png` are treated as the same type.
+
 #### ValidFileResolvable
 
 Does the same thing as `ValidFile` constraint but resolves allowedContentTypeList, allowedExtensionList and allowedFileNameRegex from Spring's `Environment` bean allowing those properties to be
@@ -233,6 +254,15 @@ public class ExampleRequest {
 
 will resolve allowedContentTypeList from `my.custom.validation.file.allowed-content-type-list`, allowedExtensionList from `my.custom.validation.file.allowed-extension-list`
 and allowedFileNameRegex from `my.custom.validation.file.allowed-file-name-regex` properties and perform validation while skipping resolved empty or null property values.
+
+The same strict-vs-lenient knobs as on `ValidFile` are exposed as resolvable property names:
+
+| attribute                        | default property name                        | default value |
+|----------------------------------|----------------------------------------------|---------------|
+| `requireContentTypePropertyName` | `nrich.constraint.file.require-content-type` | `true`        |
+| `requireExtensionPropertyName`   | `nrich.constraint.file.require-extension`    | `true`        |
+
+Setting `nrich.constraint.file.require-content-type=false` (or `nrich.constraint.file.require-extension=false`) restores the legacy behaviour of skipping that gate when the corresponding input is missing.
 
 ### ValidOib
 

--- a/nrich-validation/src/main/java/net/croz/nrich/validation/constraint/validator/BaseValidFileValidator.java
+++ b/nrich-validation/src/main/java/net/croz/nrich/validation/constraint/validator/BaseValidFileValidator.java
@@ -21,7 +21,6 @@ import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -38,6 +37,10 @@ abstract class BaseValidFileValidator {
     protected String[] allowedExtensionList;
 
     protected String allowedFileNameRegex;
+
+    protected boolean requireContentType;
+
+    protected boolean requireExtension;
 
     protected boolean isValid(Object value) {
         if (value == null) {
@@ -61,8 +64,13 @@ abstract class BaseValidFileValidator {
         }
 
         boolean valid = true;
-        if (fileContentType != null && allowedContentTypeList.length > 0) {
-            valid = List.of(allowedContentTypeList).contains(fileContentType);
+        if (allowedContentTypeList.length > 0) {
+            if (fileContentType == null) {
+                valid = !requireContentType;
+            }
+            else {
+                valid = Arrays.stream(allowedContentTypeList).anyMatch(fileContentType::equalsIgnoreCase);
+            }
         }
         if (!allowedFileNameRegex.isEmpty()) {
             valid &= fileName.matches(allowedFileNameRegex);
@@ -78,7 +86,10 @@ abstract class BaseValidFileValidator {
                 extension = null;
             }
 
-            if (extension != null) {
+            if (extension == null) {
+                valid &= !requireExtension;
+            }
+            else {
                 valid &= Arrays.stream(allowedExtensionList).anyMatch(extension::equalsIgnoreCase);
             }
         }

--- a/nrich-validation/src/main/java/net/croz/nrich/validation/constraint/validator/ValidFileResolvableValidator.java
+++ b/nrich-validation/src/main/java/net/croz/nrich/validation/constraint/validator/ValidFileResolvableValidator.java
@@ -37,6 +37,8 @@ public class ValidFileResolvableValidator extends BaseValidFileValidator impleme
         this.allowedContentTypeList = resolvePropertyValue(constraintAnnotation.allowedContentTypeListPropertyName(), String[].class, new String[0]);
         this.allowedExtensionList = resolvePropertyValue(constraintAnnotation.allowedExtensionListPropertyName(), String[].class, new String[0]);
         this.allowedFileNameRegex = resolvePropertyValue(constraintAnnotation.allowedFileNameRegexPropertyName(), String.class, "");
+        this.requireContentType = resolvePropertyValue(constraintAnnotation.requireContentTypePropertyName(), Boolean.class, true);
+        this.requireExtension = resolvePropertyValue(constraintAnnotation.requireExtensionPropertyName(), Boolean.class, true);
     }
 
     @Override

--- a/nrich-validation/src/main/java/net/croz/nrich/validation/constraint/validator/ValidFileValidator.java
+++ b/nrich-validation/src/main/java/net/croz/nrich/validation/constraint/validator/ValidFileValidator.java
@@ -29,6 +29,8 @@ public class ValidFileValidator extends BaseValidFileValidator implements Constr
         this.allowedContentTypeList = constraintAnnotation.allowedContentTypeList();
         this.allowedExtensionList = constraintAnnotation.allowedExtensionList();
         this.allowedFileNameRegex = constraintAnnotation.allowedFileNameRegex();
+        this.requireContentType = constraintAnnotation.requireContentType();
+        this.requireExtension = constraintAnnotation.requireExtension();
     }
 
     @Override

--- a/nrich-validation/src/test/java/net/croz/nrich/validation/constraint/stub/ValidFileResolvableValidatorLenientMultipartFileTestRequest.java
+++ b/nrich-validation/src/test/java/net/croz/nrich/validation/constraint/stub/ValidFileResolvableValidatorLenientMultipartFileTestRequest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.validation.constraint.stub;
+
+import net.croz.nrich.validation.api.constraint.ValidFileResolvable;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ValidFileResolvableValidatorLenientMultipartFileTestRequest(@ValidFileResolvable(
+    allowedContentTypeListPropertyName = "my.lenient.validation.file.allowed-content-type-list",
+    allowedExtensionListPropertyName = "my.lenient.validation.file.allowed-extension-list",
+    requireContentTypePropertyName = "my.lenient.validation.file.require-content-type",
+    requireExtensionPropertyName = "my.lenient.validation.file.require-extension"
+) MultipartFile file) {
+
+}

--- a/nrich-validation/src/test/java/net/croz/nrich/validation/constraint/stub/ValidFileValidatorLenientMultipartFileTestRequest.java
+++ b/nrich-validation/src/test/java/net/croz/nrich/validation/constraint/stub/ValidFileValidatorLenientMultipartFileTestRequest.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2020-2023 CROZ d.o.o, the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package net.croz.nrich.validation.constraint.stub;
+
+import net.croz.nrich.validation.api.constraint.ValidFile;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ValidFileValidatorLenientMultipartFileTestRequest(
+    @ValidFile(allowedContentTypeList = "text/plain", allowedExtensionList = "txt", requireContentType = false, requireExtension = false) MultipartFile file) {
+
+}

--- a/nrich-validation/src/test/java/net/croz/nrich/validation/constraint/validator/ValidFileResolvableValidatorTest.java
+++ b/nrich-validation/src/test/java/net/croz/nrich/validation/constraint/validator/ValidFileResolvableValidatorTest.java
@@ -21,11 +21,12 @@ import net.croz.nrich.validation.ValidationTestConfiguration;
 import net.croz.nrich.validation.constraint.stub.ValidFileResolvableValidatorEmptyPropertyTestRequest;
 import net.croz.nrich.validation.constraint.stub.ValidFileResolvableValidatorFilePartTestRequest;
 import net.croz.nrich.validation.constraint.stub.ValidFileResolvableValidatorInvalidTypeFileTestRequest;
+import net.croz.nrich.validation.constraint.stub.ValidFileResolvableValidatorLenientMultipartFileTestRequest;
 import net.croz.nrich.validation.constraint.stub.ValidFileResolvableValidatorMultipartFileCustomTestRequest;
 import net.croz.nrich.validation.constraint.stub.ValidFileResolvableValidatorMultipartFileTestRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -128,11 +129,11 @@ class ValidFileResolvableValidatorTest {
         assertThat(thrown.getCause()).isInstanceOf(IllegalArgumentException.class);
     }
 
-    @ValueSource(strings = { "someFile.txt", "someFile", "c:\\someFile.txt", "c:/someFile.txt" })
+    @CsvSource({ "someFile.txt, text/plain", "someFile.txt, TEXT/PLAIN", "c:\\someFile.txt, text/plain", "c:/someFile.txt, text/plain" })
     @ParameterizedTest
-    void shouldValidateMultipartFilename(String fileName) {
+    void shouldNotReportErrorForValidMultipartFile(String filename, String contentType) {
         // given
-        MultipartFile file = new MockMultipartFile("file", fileName, null, FILE_BYTES);
+        MultipartFile file = new MockMultipartFile("file", filename, contentType, FILE_BYTES);
         ValidFileResolvableValidatorMultipartFileTestRequest request = new ValidFileResolvableValidatorMultipartFileTestRequest(file);
 
         // when
@@ -140,6 +141,34 @@ class ValidFileResolvableValidatorTest {
 
         // then
         assertThat(constraintViolationList).isEmpty();
+    }
+
+    @CsvSource(value = { "someFile.txt, null", "someFile, text/plain" }, nullValues = "null")
+    @ParameterizedTest
+    void shouldNotReportErrorWhenContentTypeOrExtensionIsMissingInLenientMode(String filename, String contentType) {
+        // given
+        MultipartFile file = new MockMultipartFile("file", filename, contentType, FILE_BYTES);
+        ValidFileResolvableValidatorLenientMultipartFileTestRequest request = new ValidFileResolvableValidatorLenientMultipartFileTestRequest(file);
+
+        // when
+        Set<ConstraintViolation<ValidFileResolvableValidatorLenientMultipartFileTestRequest>> constraintViolationList = validator.validate(request);
+
+        // then
+        assertThat(constraintViolationList).isEmpty();
+    }
+
+    @CsvSource(value = { "someFile.txt, null", "someFile, null", "someFile, text/plain" }, nullValues = "null")
+    @ParameterizedTest
+    void shouldReportErrorWhenContentTypeOrExtensionIsMissingForMultipartFile(String filename, String contentType) {
+        // given
+        MultipartFile file = new MockMultipartFile("file", filename, contentType, FILE_BYTES);
+        ValidFileResolvableValidatorMultipartFileTestRequest request = new ValidFileResolvableValidatorMultipartFileTestRequest(file);
+
+        // when
+        Set<ConstraintViolation<ValidFileResolvableValidatorMultipartFileTestRequest>> constraintViolationList = validator.validate(request);
+
+        // then
+        assertThat(constraintViolationList).isNotEmpty();
     }
 
     @Test

--- a/nrich-validation/src/test/java/net/croz/nrich/validation/constraint/validator/ValidFileValidatorTest.java
+++ b/nrich-validation/src/test/java/net/croz/nrich/validation/constraint/validator/ValidFileValidatorTest.java
@@ -20,12 +20,13 @@ package net.croz.nrich.validation.constraint.validator;
 import net.croz.nrich.validation.ValidationTestConfiguration;
 import net.croz.nrich.validation.constraint.stub.ValidFileValidatorFilePartTestRequest;
 import net.croz.nrich.validation.constraint.stub.ValidFileValidatorInvalidTypeFileTestRequest;
+import net.croz.nrich.validation.constraint.stub.ValidFileValidatorLenientMultipartFileTestRequest;
 import net.croz.nrich.validation.constraint.stub.ValidFileValidatorMultipartFileTestRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -68,15 +69,14 @@ class ValidFileValidatorTest {
             Arguments.of(new MockMultipartFile("file", "**.txt", null, FILE_BYTES)),
             Arguments.of(new MockMultipartFile("file", "1.exe", null, FILE_BYTES)),
             Arguments.of(new MockMultipartFile("1.txt", "1.txt", "application/json", FILE_BYTES))
-
         );
     }
 
-    @ValueSource(strings = { "1.txt", "1", "c:\\1.txt", "c:/1.txt" })
+    @CsvSource({ "1.txt, text/plain", "1.txt, TEXT/PLAIN", "c:\\1.txt, text/plain", "c:/1.txt, text/plain" })
     @ParameterizedTest
-    void shouldNotReportErrorForValidMultipartFile(String filename) {
+    void shouldNotReportErrorForValidMultipartFile(String filename, String contentType) {
         // given
-        MultipartFile file = new MockMultipartFile("file", filename, null, FILE_BYTES);
+        MultipartFile file = new MockMultipartFile("file", filename, contentType, FILE_BYTES);
         ValidFileValidatorMultipartFileTestRequest request = new ValidFileValidatorMultipartFileTestRequest(file);
 
         // when
@@ -84,6 +84,34 @@ class ValidFileValidatorTest {
 
         // then
         assertThat(constraintViolationList).isEmpty();
+    }
+
+    @CsvSource(value = { "1.txt, null", "1, text/plain" }, nullValues = "null")
+    @ParameterizedTest
+    void shouldNotReportErrorWhenContentTypeOrExtensionIsMissingInLenientMode(String filename, String contentType) {
+        // given
+        MultipartFile file = new MockMultipartFile("file", filename, contentType, FILE_BYTES);
+        ValidFileValidatorLenientMultipartFileTestRequest request = new ValidFileValidatorLenientMultipartFileTestRequest(file);
+
+        // when
+        Set<ConstraintViolation<ValidFileValidatorLenientMultipartFileTestRequest>> constraintViolationList = validator.validate(request);
+
+        // then
+        assertThat(constraintViolationList).isEmpty();
+    }
+
+    @CsvSource(value = { "1.txt, null", "1, null", "1, text/plain" }, nullValues = "null")
+    @ParameterizedTest
+    void shouldReportErrorWhenContentTypeOrExtensionIsMissingForMultipartFile(String filename, String contentType) {
+        // given
+        MultipartFile file = new MockMultipartFile("file", filename, contentType, FILE_BYTES);
+        ValidFileValidatorMultipartFileTestRequest request = new ValidFileValidatorMultipartFileTestRequest(file);
+
+        // when
+        Set<ConstraintViolation<ValidFileValidatorMultipartFileTestRequest>> constraintViolationList = validator.validate(request);
+
+        // then
+        assertThat(constraintViolationList).isNotEmpty();
     }
 
     @Test

--- a/nrich-validation/src/test/resources/application.properties
+++ b/nrich-validation/src/test/resources/application.properties
@@ -22,3 +22,8 @@ nrich.constraint.file.allowed-file-name-regex=(?U)[\\w-.]+
 my.custom.validation.file.allowed-content-type-list=application/pdf
 my.custom.validation.file.allowed-extension-list=pdf
 my.custom.validation.file.allowed-file-name-regex=(?U)[\\w-.]+
+
+my.lenient.validation.file.allowed-content-type-list=text/plain
+my.lenient.validation.file.allowed-extension-list=txt
+my.lenient.validation.file.require-content-type=false
+my.lenient.validation.file.require-extension=false


### PR DESCRIPTION
…nstraints. Now constraints will fail if no content type or extension are present by default

<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.13.0
* Module:
nrich-validation

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Default to strict validation for ValidFile and ValidFileResolvable constraints. Now constraints will fail if no content type or extension are present by default.

### Details

Default to strict validation for ValidFile and ValidFileResolvable constraints. Now constraints will fail if no content type or extension are present by default.


### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
