### PR TITLE
Add test for autoSizeColumns to make sure future POI version upgrades…

### DIFF
--- a/nrich-excel/src/test/java/net/croz/nrich/excel/service/DefaultExcelReportServiceTest.java
+++ b/nrich-excel/src/test/java/net/croz/nrich/excel/service/DefaultExcelReportServiceTest.java
@@ -22,6 +22,8 @@ import net.croz.nrich.excel.api.model.MultiRowDataProvider;
 import net.croz.nrich.excel.api.request.CreateExcelReportRequest;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -86,6 +88,25 @@ class DefaultExcelReportServiceTest {
 
         // then
         assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage("Row data provider cannot be null!");
+    }
+
+    @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "POI's autoSizeColumn relies on AWT font metrics; since Windows produces narrower widths this test fails on Windows")
+    void shouldAutoSizeColumns() {
+        // given
+        String wideContent = "x".repeat(80);
+        Object[][] rowData = { { "x", wideContent } };
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        CreateExcelReportRequest request = createExcelReportRequest(rowData, 10, outputStream, TEMPLATE_DATA_FIRST_ROW_INDEX);
+
+        // when
+        excelReportService.createExcelReport(request);
+
+        // then
+        Sheet sheet = createWorkbookAndResolveSheet(outputStream);
+
+        // then
+        assertThat(sheet.getColumnWidth(1)).isGreaterThanOrEqualTo(wideContent.length() * 256);
     }
 
     @Test


### PR DESCRIPTION
… still work calculates column size corretly and doesn't shorten text

<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.13.0
* Module:
nrich-excel
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add test for autoSizeColumns to make sure future POI version upgrades still work calculates column size corretly and doesn't shorten text

### Details

Add test for autoSizeColumns to make sure future POI version upgrades still work calculates column size corretly and doesn't shorten text

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
