### PR TITLE
Feature jpa search executor improvements

### DIFF
--- a/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaSearchExecutor.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaSearchExecutor.java
@@ -57,7 +57,7 @@ public class JpaSearchExecutor<T> implements SearchExecutor<T> {
         CriteriaQuery<P> query = queryBuilder.buildQuery(request, searchConfiguration, Sort.unsorted());
 
         try {
-            return Optional.of(entityManager.createQuery(query).getSingleResult());
+            return Optional.of(entityManager.createQuery(query).setMaxResults(2).getSingleResult());
         }
         catch (NoResultException ignored) {
             return Optional.empty();

--- a/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaStringSearchExecutor.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaStringSearchExecutor.java
@@ -67,7 +67,7 @@ public class JpaStringSearchExecutor<T> implements StringSearchExecutor<T> {
         CriteriaQuery<P> query = queryBuilder.buildQuery(searchMap, searchConfiguration, Sort.unsorted());
 
         try {
-            return Optional.of(entityManager.createQuery(query).getSingleResult());
+            return Optional.of(entityManager.createQuery(query).setMaxResults(2).getSingleResult());
         }
         catch (NoResultException ignored) {
             return Optional.empty();

--- a/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaStringSearchExecutor.java
+++ b/nrich-search/src/main/java/net/croz/nrich/search/repository/JpaStringSearchExecutor.java
@@ -57,7 +57,7 @@ public class JpaStringSearchExecutor<T> implements StringSearchExecutor<T> {
         this.entityManager = entityManager;
         domainClass = jpaEntityInformation.getJavaType();
         queryBuilder = new JpaQueryBuilder<>(entityManager, jpaEntityInformation.getJavaType());
-        managedType = jpaEntityInformation.getRequiredIdAttribute().getDeclaringType();
+        managedType = entityManager.getMetamodel().managedType(domainClass);
     }
 
     @Override


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.13.0
* Module:
nrich-search

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Add max results limit to findOne methods and change resolving of managedType in JpaStringSearchExecutor

### Details

Add max results limit to findOne methods and change resolving of managedType in JpaStringSearchExecutor

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->


- Enhancement (non-breaking change which enhances existing functionality)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- ~~I have added tests to cover my changes~~
- [x] All new and existing tests pass.
