### PR TITLE
Fix nrich validation autoconfiguration ordering

### DIFF
--- a/nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfiguration.java
+++ b/nrich-validation-spring-boot-starter/src/main/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfiguration.java
@@ -22,9 +22,11 @@ import net.croz.nrich.validation.api.mapping.ConstraintValidatorRegistrar;
 import net.croz.nrich.validation.constraint.mapping.DefaultConstraintValidatorRegistrar;
 import net.croz.nrich.validation.starter.properties.NrichValidationProperties;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
 import org.springframework.boot.autoconfigure.validation.ValidationConfigurationCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.MessageSource;
@@ -34,6 +36,7 @@ import org.springframework.context.support.AbstractResourceBasedMessageSource;
 
 import jakarta.validation.Validator;
 
+@AutoConfigureAfter(ValidationAutoConfiguration.class)
 @EnableConfigurationProperties(NrichValidationProperties.class)
 @Configuration(proxyBeanMethods = false)
 public class NrichValidationAutoConfiguration {

--- a/nrich-validation-spring-boot-starter/src/test/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfigurationTest.java
+++ b/nrich-validation-spring-boot-starter/src/test/java/net/croz/nrich/validation/starter/configuration/NrichValidationAutoConfigurationTest.java
@@ -22,11 +22,13 @@ import net.croz.nrich.validation.starter.properties.NrichValidationProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
 import org.springframework.boot.autoconfigure.validation.ValidationConfigurationCustomizer;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.MessageSource;
 import org.springframework.context.support.AbstractResourceBasedMessageSource;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import jakarta.validation.Validator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -50,7 +52,10 @@ class NrichValidationAutoConfigurationTest {
     @Test
     void shouldRegisterValidationPropertiesCustomizer() {
         // expect
-        contextRunner.withBean(LocalValidatorFactoryBean.class).run(context -> assertThat(context).hasSingleBean(HibernatePropertiesCustomizer.class));
+        contextRunner.withConfiguration(AutoConfigurations.of(ValidationAutoConfiguration.class)).run(context -> {
+            assertThat(context).hasSingleBean(Validator.class);
+            assertThat(context).hasSingleBean(HibernatePropertiesCustomizer.class);
+        });
     }
 
     @Test


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* nrich version:
2.13.0
* Module:

nrich-validation-spring-boot-starter

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. Java, Gradle/Maven, OS version). -->

## Description

### Summary

Fix nrich validation autoconfiguration ordering

### Details

Fix nrich validation autoconfiguration ordering so it is executed after springs validation autoconfiguration

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in gradle build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- ~~My change requires a change to the documentation~~
- ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
